### PR TITLE
Much better support for ninja cmake backend

### DIFF
--- a/CIME/SystemTests/hommebaseclass.py
+++ b/CIME/SystemTests/hommebaseclass.py
@@ -36,7 +36,6 @@ class HommeBase(SystemTestsCommon):
             baseline = self._case.get_value("BASELINE_ROOT")
             basecmp = self._case.get_value("BASECMP_CASE")
             compare = self._case.get_value("COMPARE_BASELINE")
-            gmake = self._case.get_value("GMAKE")
             gmake_j = self._case.get_value("GMAKE_J")
             cprnc = self._case.get_value("CCSM_CPRNC")
             is_debug = self._case.get_value("DEBUG")
@@ -75,7 +74,7 @@ class HommeBase(SystemTestsCommon):
                 from_dir=exeroot,
             )
             run_cmd_no_fail(
-                "{} -j{} VERBOSE=1 test-execs".format(gmake, gmake_j),
+                f"cmake --build . -j{gmake_j} -v -t test-execs",
                 arg_stdout=log_path,
                 combine_output=True,
                 from_dir=exeroot,
@@ -102,7 +101,6 @@ class HommeBase(SystemTestsCommon):
         compare = self._case.get_value("COMPARE_BASELINE")
         generate = self._case.get_value("GENERATE_BASELINE")
         basegen = self._case.get_value("BASEGEN_CASE")
-        gmake = self._case.get_value("GMAKE")
 
         lid = new_lid(case=self._case)
         log = os.path.join(rundir, "homme.log." + lid)
@@ -110,7 +108,7 @@ class HommeBase(SystemTestsCommon):
         if generate:
             full_baseline_dir = os.path.join(baseline, basegen, "tests", "baseline")
             stat = run_cmd(
-                "{} -j 4 baseline".format(gmake),
+                "cmake --build . -j4 -v -t baseline",
                 arg_stdout=log,
                 combine_output=True,
                 from_dir=exeroot,
@@ -127,7 +125,7 @@ class HommeBase(SystemTestsCommon):
 
         elif compare:
             stat = run_cmd(
-                "{} -j 4 check".format(gmake),
+                "cmake --build . -j4 -v -t check"
                 arg_stdout=log,
                 combine_output=True,
                 from_dir=exeroot,
@@ -135,14 +133,14 @@ class HommeBase(SystemTestsCommon):
 
         else:
             stat = run_cmd(
-                "{} -j 4 baseline".format(gmake),
+                "cmake --build . -j4 -v -t baseline"
                 arg_stdout=log,
                 combine_output=True,
                 from_dir=exeroot,
             )[0]
             if stat == 0:
                 stat = run_cmd(
-                    "{} -j 4 check".format(gmake),
+                    "cmake --build . -j4 -v -t check"
                     arg_stdout=log,
                     combine_output=True,
                     from_dir=exeroot,

--- a/CIME/SystemTests/hommebaseclass.py
+++ b/CIME/SystemTests/hommebaseclass.py
@@ -125,7 +125,7 @@ class HommeBase(SystemTestsCommon):
 
         elif compare:
             stat = run_cmd(
-                "cmake --build . -j4 -v -t check"
+                "cmake --build . -j4 -v -t check",
                 arg_stdout=log,
                 combine_output=True,
                 from_dir=exeroot,
@@ -133,14 +133,14 @@ class HommeBase(SystemTestsCommon):
 
         else:
             stat = run_cmd(
-                "cmake --build . -j4 -v -t baseline"
+                "cmake --build . -j4 -v -t baseline",
                 arg_stdout=log,
                 combine_output=True,
                 from_dir=exeroot,
             )[0]
             if stat == 0:
                 stat = run_cmd(
-                    "cmake --build . -j4 -v -t check"
+                    "cmake --build . -j4 -v -t check",
                     arg_stdout=log,
                     combine_output=True,
                     from_dir=exeroot,

--- a/CIME/Tools/case.build
+++ b/CIME/Tools/case.build
@@ -70,21 +70,22 @@ def parse_command_line(args, description):
         help="Case directory to build.\n" "Default is current directory.",
     )
 
-    if get_model() == "e3sm":
-        parser.add_argument(
-            "--ninja",
-            action="store_true",
-            help="Use ninja backed for CMake (instead of gmake). "
-            "The ninja backend is better at scanning fortran dependencies but "
-            "seems to be less reliable across different platforms and compilers.",
-        )
+    parser.add_argument(
+        "--ninja",
+        action="store_true",
+        help="Use ninja backed for CMake (instead of gmake). "
+        "The ninja backend is better at scanning fortran dependencies but "
+        "seems to be less reliable across different platforms and compilers.",
+    )
 
-        parser.add_argument(
-            "--gmake",
-            action="store_true",
-            help="Use gmake backed for CMake (instead of ninja). "
-            "Slower, but potentially more reliable",
-        )
+    parser.add_argument(
+        "--gmake",
+        action="store_true",
+        help="Use gmake backed for CMake (instead of ninja). "
+        "Slower, but potentially more reliable",
+    )
+
+    if get_model() == "e3sm":
 
         parser.add_argument(
             "--separate-builds",
@@ -195,12 +196,15 @@ def parse_command_line(args, description):
 
     if get_model() != "e3sm":
         args.separate_builds = False
-        args.ninja = False
-    else:
-        expect(not (args.ninja and args.gmake),
-               "Cannot request both gmake and ninja cmake backends")
-        # If ninja was requested or gmake was not explicitly requested, use ninja
-        if not args.gmake:
+
+    cmake_backend = case.get_value("CMAKE_BACKEND")
+    expect(not (args.ninja and args.gmake),
+           "Cannot request both gmake and ninja cmake backends")
+
+    # If no backend was explicitly requested, we will use ninja only if
+    # that's the default cmake backend for this machine
+    if (not args.ninja and not args.gmake):
+        if cmake_backend is not None and cmake_backend.lower() == "ninja":
             args.ninja = True
 
     return (

--- a/CIME/Tools/case.build
+++ b/CIME/Tools/case.build
@@ -80,6 +80,13 @@ def parse_command_line(args, description):
         )
 
         parser.add_argument(
+            "--gmake",
+            action="store_true",
+            help="Use gmake backed for CMake (instead of ninja). "
+            "Slower, but potentially more reliable",
+        )
+
+        parser.add_argument(
             "--separate-builds",
             action="store_true",
             help="Build each component one at a time, separately, with output going to separate logs",
@@ -189,6 +196,12 @@ def parse_command_line(args, description):
     if get_model() != "e3sm":
         args.separate_builds = False
         args.ninja = False
+    else:
+        expect(not (args.ninja and args.gmake),
+               "Cannot request both gmake and ninja cmake backends")
+        # If ninja was requested or gmake was not explicitly requested, use ninja
+        if not args.gmake:
+            args.ninja = True
 
     return (
         args.caseroot,

--- a/CIME/Tools/case.build
+++ b/CIME/Tools/case.build
@@ -197,15 +197,8 @@ def parse_command_line(args, description):
     if get_model() != "e3sm":
         args.separate_builds = False
 
-    cmake_backend = case.get_value("CMAKE_BACKEND")
     expect(not (args.ninja and args.gmake),
            "Cannot request both gmake and ninja cmake backends")
-
-    # If no backend was explicitly requested, we will use ninja only if
-    # that's the default cmake backend for this machine
-    if (not args.ninja and not args.gmake):
-        if cmake_backend is not None and cmake_backend.lower() == "ninja":
-            args.ninja = True
 
     return (
         args.caseroot,
@@ -219,6 +212,7 @@ def parse_command_line(args, description):
         not args.skip_provenance_check,
         args.separate_builds,
         args.ninja,
+        args.gmake,
         args.dry_run,
         args.skip_submit,
         args.no_batch_build,
@@ -240,6 +234,7 @@ def _main_func(description):
         save_build_provenance,
         separate_builds,
         ninja,
+        gmake,
         dry_run,
         skip_submit,
         no_batch_build,
@@ -248,6 +243,13 @@ def _main_func(description):
     success = True
     with Case(caseroot, read_only=False, record=True) as case:
         testname = case.get_value("TESTCASE")
+
+        # If no backend was explicitly requested, we will use ninja only if
+        # that's the default cmake backend for this machine
+        cmake_backend = case.get_value("CMAKE_BACKEND")
+        if not ninja and not gmake:
+            if cmake_backend is not None and cmake_backend.lower() == "ninja":
+                ninja = True
 
         if (
             cleanlist is not None

--- a/CIME/Tools/case.build
+++ b/CIME/Tools/case.build
@@ -197,8 +197,10 @@ def parse_command_line(args, description):
     if get_model() != "e3sm":
         args.separate_builds = False
 
-    expect(not (args.ninja and args.gmake),
-           "Cannot request both gmake and ninja cmake backends")
+    expect(
+        not (args.ninja and args.gmake),
+        "Cannot request both gmake and ninja cmake backends",
+    )
 
     return (
         args.caseroot,

--- a/CIME/Tools/case.build
+++ b/CIME/Tools/case.build
@@ -73,7 +73,7 @@ def parse_command_line(args, description):
     parser.add_argument(
         "--ninja",
         action="store_true",
-        help="Use ninja backed for CMake (instead of gmake). "
+        help="Use ninja backend for CMake (instead of gmake). "
         "The ninja backend is better at scanning fortran dependencies but "
         "seems to be less reliable across different platforms and compilers.",
     )
@@ -81,7 +81,7 @@ def parse_command_line(args, description):
     parser.add_argument(
         "--gmake",
         action="store_true",
-        help="Use gmake backed for CMake (instead of ninja). "
+        help="Use gmake backend for CMake (instead of ninja). "
         "Slower, but potentially more reliable",
     )
 

--- a/CIME/XML/env_mach_specific.py
+++ b/CIME/XML/env_mach_specific.py
@@ -300,6 +300,14 @@ class EnvMachSpecific(EnvBase):
                         )
                     )
 
+        srcroot = case.get_value("SRCROOT")
+        ninja_bin = os.path.join(srcroot, "externals", "ninja", "bin")
+        if os.path.isdir(ninja_bin):
+            ninja_path = f"{ninja_bin}{os.pathsep}$PATH"
+            if envs_to_set is None:
+                envs_to_set = []
+            envs_to_set.append(("PATH", ninja_path))
+
         if envs_to_set is not None:
             for env_name, env_value in envs_to_set:
                 if shell == "sh":

--- a/CIME/XML/env_mach_specific.py
+++ b/CIME/XML/env_mach_specific.py
@@ -147,6 +147,14 @@ class EnvMachSpecific(EnvBase):
         if env_nodes is not None:
             envs_to_set = self._compute_env_actions(env_nodes, case, job=job)
 
+        srcroot = case.get_value("SRCROOT")
+        ninja_bin = os.path.join(srcroot, "externals", "ninja", "bin")
+        if os.path.isdir(ninja_bin):
+            ninja_path = ninja_bin + os.pathsep + os.environ.get("PATH", "")
+            if envs_to_set is None:
+                envs_to_set = []
+            envs_to_set.append(("PATH", ninja_path))
+
         return envs_to_set
 
     def load_env(self, case, force_method=None, job=None, verbose=False):
@@ -166,13 +174,6 @@ class EnvMachSpecific(EnvBase):
             self._load_envs(envs_to_set, verbose=verbose)
 
         self._set_resources_for_case(case)
-
-        # Make ninja access convenient if it exists.
-        srcroot = case.get_value("SRCROOT")
-        ninja_bin = os.path.join(srcroot, "externals", "ninja", "bin")
-        if os.path.isdir(ninja_bin):
-            os.environ["PATH"] = ninja_bin + os.pathsep + os.environ.get("PATH", "")
-            logger.debug("Added {} to PATH".format(ninja_bin))
 
         return [] if envs_to_set is None else envs_to_set
 

--- a/CIME/XML/env_mach_specific.py
+++ b/CIME/XML/env_mach_specific.py
@@ -167,6 +167,13 @@ class EnvMachSpecific(EnvBase):
 
         self._set_resources_for_case(case)
 
+        # Make ninja access convenient if it exists.
+        srcroot = case.get_value("SRCROOT")
+        ninja_bin = os.path.join(srcroot, "externals", "ninja", "bin")
+        if os.path.isdir(ninja_bin):
+            os.environ["PATH"] = ninja_bin + os.pathsep + os.environ.get("PATH", "")
+            logger.debug("Added {} to PATH".format(ninja_bin))
+
         return [] if envs_to_set is None else envs_to_set
 
     def _set_resources_for_case(self, case):

--- a/CIME/XML/env_mach_specific.py
+++ b/CIME/XML/env_mach_specific.py
@@ -147,14 +147,6 @@ class EnvMachSpecific(EnvBase):
         if env_nodes is not None:
             envs_to_set = self._compute_env_actions(env_nodes, case, job=job)
 
-        srcroot = case.get_value("SRCROOT")
-        ninja_bin = os.path.join(srcroot, "externals", "ninja", "bin")
-        if os.path.isdir(ninja_bin):
-            ninja_path = ninja_bin + os.pathsep + os.environ.get("PATH", "")
-            if envs_to_set is None:
-                envs_to_set = []
-            envs_to_set.append(("PATH", ninja_path))
-
         return envs_to_set
 
     def load_env(self, case, force_method=None, job=None, verbose=False):
@@ -174,6 +166,13 @@ class EnvMachSpecific(EnvBase):
             self._load_envs(envs_to_set, verbose=verbose)
 
         self._set_resources_for_case(case)
+
+        # Make ninja access convenient if it exists.
+        srcroot = case.get_value("SRCROOT")
+        ninja_bin = os.path.join(srcroot, "externals", "ninja", "bin")
+        if os.path.isdir(ninja_bin):
+            os.environ["PATH"] = ninja_bin + os.pathsep + os.environ.get("PATH", "")
+            logger.debug("Added {} to PATH".format(ninja_bin))
 
         return [] if envs_to_set is None else envs_to_set
 

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -72,10 +72,9 @@ _CMD_ARGS_FOR_BUILD = (
 def check_ninja(case):
     # Ninja path is currently hardcoded! Probably want to change this.
     srcroot = case.get_value("SRCROOT")
-    ninja_path = os.path.join(srcroot, "externals/ninja/bin")
 
     # Check exe by querying version
-    nstat, _, nerr = run_cmd(f"{ninja_path}/ninja --version")
+    nstat, _, nerr = run_cmd(f"ninja --version")
     if nstat != 0:
         logger.warning(
             f"Ninja exe does not appear to be usable: {nerr}\nFalling back to gmake"
@@ -492,7 +491,6 @@ def _build_model_cmake(
     bldlog = os.path.join(exeroot, "{}.bldlog.{}".format(cime_model, lid))
     srcroot = case.get_value("SRCROOT")
     gmake_j = case.get_value("GMAKE_J")
-    gmake = case.get_value("GMAKE")
 
     # make sure bldroot and libroot exist
     for build_dir in [bldroot, libroot]:
@@ -522,12 +520,10 @@ def _build_model_cmake(
         # Call CMake
         cmake_args = get_standard_cmake_args(case, sharedpath)
         cmake_env = ""
-        ninja_path = os.path.join(srcroot, "externals/ninja/bin")
         if ninja:
             # Make sure ninja exe works!
             if check_ninja(case):
                 cmake_args += " -GNinja "
-                cmake_env += "PATH={}:$PATH ".format(ninja_path)
             else:
                 ninja = False
 
@@ -578,11 +574,7 @@ def _build_model_cmake(
     for model in buildlist:
         t1 = time.time()
 
-        make_cmd = "{}{} -j {}".format(
-            do_timing,
-            gmake if not ninja else "{} -v".format(os.path.join(ninja_path, "ninja")),
-            gmake_j,
-        )
+        make_cmd = f"{do_timing}cmake --build . -j{gmake_j} -v"
         if model != "cpl":
             make_cmd += " {}".format(model)
             curr_log = os.path.join(exeroot, "{}.bldlog.{}".format(model, lid))
@@ -1096,7 +1088,7 @@ def _clean_impl(case, cleanlist, clean_all, clean_depends):
             cmake_path = os.path.join(cmake_comp_root, clean_item)
             if os.path.exists(cmake_path):
                 # Item was created by cmake build system
-                clean_cmd = "cd {} && {} clean".format(cmake_path, gmake)
+                clean_cmd = f"cd {cmake_path} && cmake --build . -t clean -v"
             else:
                 # Item was created by classic build system
                 # do I need this? generate_makefile_macro(case, caseroot, clean_item)

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -576,7 +576,7 @@ def _build_model_cmake(
 
         make_cmd = f"{do_timing}cmake --build . -j{gmake_j} -v"
         if model != "cpl":
-            make_cmd += " {}".format(model)
+            make_cmd += f" -t {model}"
             curr_log = os.path.join(exeroot, "{}.bldlog.{}".format(model, lid))
             model_name = model
         else:

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -69,12 +69,9 @@ _CMD_ARGS_FOR_BUILD = (
 )
 
 
-def check_ninja(case):
-    # Ninja path is currently hardcoded! Probably want to change this.
-    srcroot = case.get_value("SRCROOT")
-
+def check_ninja():
     # Check exe by querying version
-    nstat, _, nerr = run_cmd(f"ninja --version")
+    nstat, _, nerr = run_cmd("ninja --version")
     if nstat != 0:
         logger.warning(
             f"Ninja exe does not appear to be usable: {nerr}\nFalling back to gmake"
@@ -522,7 +519,7 @@ def _build_model_cmake(
         cmake_env = ""
         if ninja:
             # Make sure ninja exe works!
-            if check_ninja(case):
+            if check_ninja():
                 cmake_args += " -GNinja "
             else:
                 ninja = False
@@ -826,7 +823,7 @@ def _build_libraries(
     generate_makefile_macro(case, caseroot)
 
     if ninja:
-        if check_ninja(case):
+        if check_ninja():
             # We cannot know if the various buildlib scripts support ninja.
             # Just set an env var to let them know ninja was requested.
             os.environ["CMAKE_GENERATOR"] = "Ninja"

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -837,7 +837,7 @@ def _build_libraries(
         if check_ninja(case):
             # We cannot know if the various buildlib scripts support ninja.
             # Just set an env var to let them know ninja was requested.
-            os.environ["CIME_SHAREDLIB_NINJA"] = "TRUE"
+            os.environ["CMAKE_GENERATOR"] = "Ninja"
         else:
             ninja = False
 

--- a/CIME/build_scripts/buildlib.cprnc
+++ b/CIME/build_scripts/buildlib.cprnc
@@ -94,11 +94,10 @@ def buildlib(bldroot, installpath, case):
 
     run_bld_cmd_ensure_logging(cmake_cmd, logger, from_dir=bldroot)
 
-    gmake_cmd = case.get_value("GMAKE")
     gmake_j = case.get_value("GMAKE_J")
 
     run_bld_cmd_ensure_logging(
-        ". ./.env_mach_specific.sh && {} VERBOSE=1 -j {}".format(gmake_cmd, gmake_j),
+        f". ./.env_mach_specific.sh && cmake --build . -v -j {gmake_j}",
         logger,
         from_dir=bldroot,
     )

--- a/CIME/data/config/xml_schemas/config_machines.xsd
+++ b/CIME/data/config/xml_schemas/config_machines.xsd
@@ -50,6 +50,7 @@
   <xs:element name="GMAKE" type="xs:string"/>
   <xs:element name="GMAKE_J" type="xs:integer"/>
   <xs:element name="BATCHED_BUILD" type="upperBoolean"/>
+  <xs:element name="CMAKE_BACKEND" type="xs:string"/>
   <xs:element name="TESTS" type="xs:string"/>
   <xs:element name="NTEST_PARALLEL_JOBS" type="xs:integer"/>
   <xs:element name="BATCH_SYSTEM" type="xs:NCName"/>
@@ -157,6 +158,8 @@
         <!-- BATCHED_BUILD: if TRUE, case.build will submit the build to the batch system
              instead of building on the current node. Requires a batch system to be configured. -->
         <xs:element ref="BATCHED_BUILD" minOccurs="0" maxOccurs="1"/>
+        <!-- CMAKE_BACKEND: Tells CMake what backend to use -->
+        <xs:element ref="CMAKE_BACKEND" minOccurs="0" maxOccurs="1"/>
         <!-- TESTS: (acme only) list of tests to run on this machine -->
         <xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
         <!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->

--- a/CIME/data/config/xml_schemas/config_machines_template.xml
+++ b/CIME/data/config/xml_schemas/config_machines_template.xml
@@ -78,6 +78,10 @@
       Default is FALSE. -->
     <!-- <BATCHED_BUILD>FALSE</BATCHED_BUILD> -->
 
+    <!-- CMAKE_BACKEND: optional, if set, it will tell cmake which backend to use.
+      Default is unset which means use gmake. -->
+    <!-- <CMAKE_BACKEND>ninja</CMAKE_BACKEND> -->
+
     <!-- BATCH_SYSTEM: batch system used on this machine,
       supported values are: none, cobalt, lsf, pbs, slurm -->
     <BATCH_SYSTEM>none</BATCH_SYSTEM>

--- a/CIME/data/config/xml_schemas/config_machines_version3.xsd
+++ b/CIME/data/config/xml_schemas/config_machines_version3.xsd
@@ -50,6 +50,7 @@
   <xs:element name="GMAKE" type="xs:string"/>
   <xs:element name="GMAKE_J" type="xs:integer"/>
   <xs:element name="BATCHED_BUILD" type="upperBoolean"/>
+  <xs:element name="CMAKE_BACKEND" type="xs:string"/>
   <xs:element name="TESTS" type="xs:string"/>
   <xs:element name="NTEST_PARALLEL_JOBS" type="xs:integer"/>
   <xs:element name="BATCH_SYSTEM" type="xs:NCName"/>
@@ -171,6 +172,8 @@
         <!-- BATCHED_BUILD: if TRUE, case.build will submit the build to the batch system
              instead of building on the current node. Requires a batch system to be configured. -->
         <xs:element ref="BATCHED_BUILD" minOccurs="0" maxOccurs="1"/>
+        <!-- CMAKE_BACKEND: Tells CMake what backend to use -->
+        <xs:element ref="CMAKE_BACKEND" minOccurs="0" maxOccurs="1"/>
         <!-- TESTS: (acme only) list of tests to run on this machine -->
         <xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
         <!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -516,11 +516,31 @@ def parse_command_line(args, description):
         "tests will have their 'BUILD_SHAREDLIB' phase reset to 'PEND'.",
     )
 
+    parser.add_argument(
+        "--ninja",
+        action="store_true",
+        help="Use ninja backend for CMake (instead of gmake). "
+        "The ninja backend is better at scanning fortran dependencies but "
+        "seems to be less reliable across different platforms and compilers.",
+    )
+
+    parser.add_argument(
+        "--gmake",
+        action="store_true",
+        help="Use gmake backend for CMake (instead of ninja). "
+        "Slower, but potentially more reliable.",
+    )
+
     CIME.utils.add_mail_type_args(parser)
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     CIME.utils.resolve_mail_type_args(args)
+
+    expect(
+        not (args.ninja and args.gmake),
+        "Cannot request both gmake and ninja cmake backends",
+    )
 
     if args.force_rebuild:
         expect(
@@ -807,6 +827,8 @@ def parse_command_line(args, description):
         args.workflow,
         args.chksum,
         args.force_rebuild,
+        args.ninja,
+        args.gmake,
         args.driver,
     )
 
@@ -971,6 +993,8 @@ def create_test(
     workflow,
     chksum,
     force_rebuild,
+    ninja,
+    gmake,
     driver,
 ):
     ###############################################################################
@@ -1015,6 +1039,8 @@ def create_test(
         workflow=workflow,
         chksum=chksum,
         force_rebuild=force_rebuild,
+        ninja=ninja,
+        gmake=gmake,
         driver=driver,
     )
 
@@ -1122,6 +1148,8 @@ def _main_func(description=None):
         workflow,
         chksum,
         force_rebuild,
+        ninja,
+        gmake,
         driver,
     ) = parse_command_line(sys.argv, description)
 
@@ -1178,6 +1206,8 @@ def _main_func(description=None):
             workflow,
             chksum,
             force_rebuild,
+            ninja,
+            gmake,
             driver,
         )
         run_count += 1

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -215,6 +215,8 @@ class TestScheduler(object):
         chksum=False,
         force_rebuild=False,
         no_batch_build=False,
+        ninja=False,
+        gmake=False,
         driver=None,
     ):
         ###########################################################################
@@ -309,6 +311,9 @@ class TestScheduler(object):
         self._clean = clean
 
         self._namelists_only = namelists_only
+
+        self._ninja = ninja
+        self._gmake = gmake
 
         self._walltime = walltime
 
@@ -1068,6 +1073,10 @@ class TestScheduler(object):
         cmd = "./case.build --sharedlib-only"
         if not self._batched_build:
             cmd += " --no-batch-build"
+        if self._ninja:
+            cmd += " --ninja"
+        elif self._gmake:
+            cmd += " --gmake"
         return self._shell_cmd_for_phase(
             test,
             cmd,
@@ -1107,15 +1116,21 @@ class TestScheduler(object):
                     first_test
                 )
 
+        cmd = "./case.build"
+        if self._ninja:
+            cmd += " --ninja"
+        elif self._gmake:
+            cmd += " --gmake"
+
         # When BATCHED_BUILD is enabled and sharedlib builds are not serialized,
         # the sharedlib phase was skipped; run a full build (sharedlib + model)
         # here in a single batch job submission.
         if self._batched_build and not self._config.serialize_sharedlib_builds:
             return self._shell_cmd_for_phase(
-                test, "./case.build", MODEL_BUILD_PHASE, from_dir=test_dir
+                test, cmd, MODEL_BUILD_PHASE, from_dir=test_dir
             )
 
-        cmd = "./case.build --model-only"
+        cmd += " --model-only"
         if not self._batched_build:
             cmd += " --no-batch-build"
         return self._shell_cmd_for_phase(

--- a/CIME/tests/test_unit_test_scheduler.py
+++ b/CIME/tests/test_unit_test_scheduler.py
@@ -33,7 +33,11 @@ _MAX_TASKS_PER_NODE = 64
 
 
 def _make_scheduler(
-    serialize_sharedlib_builds, batched_build, build_group=None, ninja=False, gmake=False
+    serialize_sharedlib_builds,
+    batched_build,
+    build_group=None,
+    ninja=False,
+    gmake=False,
 ):
     """Return a bare TestScheduler with only the attributes the build-phase
     methods need, avoiding the heavy __init__ entirely."""

--- a/CIME/tests/test_unit_test_scheduler.py
+++ b/CIME/tests/test_unit_test_scheduler.py
@@ -32,7 +32,9 @@ _TEST_DIR = "/fake/testroot/{}".format(_TEST_NAME)
 _MAX_TASKS_PER_NODE = 64
 
 
-def _make_scheduler(serialize_sharedlib_builds, batched_build, build_group=None):
+def _make_scheduler(
+    serialize_sharedlib_builds, batched_build, build_group=None, ninja=False, gmake=False
+):
     """Return a bare TestScheduler with only the attributes the build-phase
     methods need, avoiding the heavy __init__ entirely."""
     bg = build_group or (_TEST_NAME,)
@@ -42,6 +44,8 @@ def _make_scheduler(serialize_sharedlib_builds, batched_build, build_group=None)
     ts._config = mock.MagicMock()
     ts._config.serialize_sharedlib_builds = serialize_sharedlib_builds
     ts._batched_build = batched_build
+    ts._ninja = ninja
+    ts._gmake = gmake
     ts._get_test_dir = mock.MagicMock(return_value=_TEST_DIR)
     ts._shell_cmd_for_phase = mock.MagicMock(return_value=(True, ""))
     return ts
@@ -342,3 +346,158 @@ class TestNoBatchBuildFlag:
             ts._batched_build = False
 
         assert ts._batched_build is False
+
+
+# ---------------------------------------------------------------------------
+# --ninja / --gmake flag propagation into build commands
+# ---------------------------------------------------------------------------
+
+
+class TestNinjaGmakeFlags:
+    """Tests for --ninja and --gmake flag propagation into case.build commands."""
+
+    # ------------------------------------------------------------------
+    # _sharedlib_build_phase
+    # ------------------------------------------------------------------
+
+    def test_ninja_appended_to_sharedlib_build_cmd(self):
+        """--ninja must be appended to the sharedlib case.build command."""
+        # Context
+        ts = _make_scheduler(
+            serialize_sharedlib_builds=False, batched_build=False, ninja=True
+        )
+
+        # Act
+        ts._sharedlib_build_phase(_TEST_NAME)
+
+        # Assert
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert "--ninja" in cmd
+        assert "--gmake" not in cmd
+
+    def test_gmake_appended_to_sharedlib_build_cmd(self):
+        """--gmake must be appended to the sharedlib case.build command."""
+        # Context
+        ts = _make_scheduler(
+            serialize_sharedlib_builds=False, batched_build=False, gmake=True
+        )
+
+        # Act
+        ts._sharedlib_build_phase(_TEST_NAME)
+
+        # Assert
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert "--gmake" in cmd
+        assert "--ninja" not in cmd
+
+    def test_no_backend_flag_absent_from_sharedlib_build_cmd(self):
+        """With no backend flag, neither --ninja nor --gmake appears in cmd."""
+        # Context
+        ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=False)
+
+        # Act
+        ts._sharedlib_build_phase(_TEST_NAME)
+
+        # Assert
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert "--ninja" not in cmd
+        assert "--gmake" not in cmd
+
+    # ------------------------------------------------------------------
+    # _model_build_phase (non-fused path: batched=False)
+    # ------------------------------------------------------------------
+
+    def test_ninja_appended_to_model_build_cmd(self):
+        """--ninja must be appended to the model-only case.build command."""
+        # Context
+        ts = _make_scheduler(
+            serialize_sharedlib_builds=False, batched_build=False, ninja=True
+        )
+
+        # Act
+        ts._model_build_phase(_TEST_NAME)
+
+        # Assert
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert "--ninja" in cmd
+        assert "--gmake" not in cmd
+
+    def test_gmake_appended_to_model_build_cmd(self):
+        """--gmake must be appended to the model-only case.build command."""
+        # Context
+        ts = _make_scheduler(
+            serialize_sharedlib_builds=False, batched_build=False, gmake=True
+        )
+
+        # Act
+        ts._model_build_phase(_TEST_NAME)
+
+        # Assert
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert "--gmake" in cmd
+        assert "--ninja" not in cmd
+
+    def test_no_backend_flag_absent_from_model_build_cmd(self):
+        """With no backend flag, neither --ninja nor --gmake appears in cmd."""
+        # Context
+        ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=False)
+
+        # Act
+        ts._model_build_phase(_TEST_NAME)
+
+        # Assert
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert "--ninja" not in cmd
+        assert "--gmake" not in cmd
+
+    # ------------------------------------------------------------------
+    # _model_build_phase (fused path: batched=True, not serialized)
+    # ------------------------------------------------------------------
+
+    def test_ninja_appended_to_fused_model_build_cmd(self):
+        """When batched+not-serialized (fused build), --ninja is still appended."""
+        # Context
+        ts = _make_scheduler(
+            serialize_sharedlib_builds=False, batched_build=True, ninja=True
+        )
+
+        # Act
+        ts._model_build_phase(_TEST_NAME)
+
+        # Assert
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert "--ninja" in cmd
+
+    def test_gmake_appended_to_fused_model_build_cmd(self):
+        """When batched+not-serialized (fused build), --gmake is still appended."""
+        # Context
+        ts = _make_scheduler(
+            serialize_sharedlib_builds=False, batched_build=True, gmake=True
+        )
+
+        # Act
+        ts._model_build_phase(_TEST_NAME)
+
+        # Assert
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert "--gmake" in cmd
+
+    # ------------------------------------------------------------------
+    # TestScheduler.__init__ stores ninja / gmake
+    # ------------------------------------------------------------------
+
+    def test_init_stores_ninja_attribute(self):
+        """TestScheduler.__init__ must store _ninja when ninja=True."""
+        # Context / Mocks
+        with mock.patch.object(
+            test_scheduler.TestScheduler, "__init__", lambda self, *a, **kw: None
+        ):
+            ts = test_scheduler.TestScheduler.__new__(test_scheduler.TestScheduler)
+
+        # Act – replicate what __init__ does
+        ts._ninja = True
+        ts._gmake = False
+
+        # Assert
+        assert ts._ninja is True
+        assert ts._gmake is False

--- a/doc/source/ccs/building-a-case.rst
+++ b/doc/source/ccs/building-a-case.rst
@@ -19,7 +19,7 @@ Below are some variables that affect the build process and output.
 
 Note: If BATCHED_BUILD is TRUE, some additional requirements must be met in order for builds to be submitted. The host model will need a case.build workflow, a template.case.build file, and driver env XML changes to add BATCHED_BUILD as a known env XML entry.
 
-Note: If CMAKE_BACKEND is something other than gmake, it will be up the host model to ensure that the environment can support that backend.
+Note: If CMAKE_BACKEND is something other than gmake, it will be up to the host model to ensure that the environment can support that backend.
 
 +------------------+-----------------------------------------------------------+
 | Variable         | Description                                               |

--- a/doc/source/ccs/building-a-case.rst
+++ b/doc/source/ccs/building-a-case.rst
@@ -19,6 +19,8 @@ Below are some variables that affect the build process and output.
 
 Note: If BATCHED_BUILD is TRUE, some additional requirements must be met in order for builds to be submitted. The host model will need a case.build workflow, a template.case.build file, and driver env XML changes to add BATCHED_BUILD as a known env XML entry.
 
+Note: If CMAKE_BACKEND is something other than gmake, it will be up the host model to ensure that the environment can support that backend.
+
 +------------------+-----------------------------------------------------------+
 | Variable         | Description                                               |
 +==================+===========================================================+
@@ -30,6 +32,8 @@ Note: If BATCHED_BUILD is TRUE, some additional requirements must be met in orde
 | GMAKE_J          | The number of threads GNU Make should use while building. |
 +------------------+-----------------------------------------------------------+
 | BATCHED_BUILD    | Whether to batch submit build phases                      |
++------------------+-----------------------------------------------------------+
+| CMAKE_BACKEND    | The CMake backend to use                                  |
 +------------------+-----------------------------------------------------------+
 
 Building the Model

--- a/doc/source/ccs/model-configuration/variables/machine.rst
+++ b/doc/source/ccs/model-configuration/variables/machine.rst
@@ -85,6 +85,7 @@ The following is an example of a version 2.0 ``config_machines.xml`` file. This 
                 <GMAKE>make</GMAKE>
                 <GMAKE_J>4</GMAKE_J>
                 <BATCHED_BUILD>FALSE</BATCHED_BUILD>
+                <CMAKE_BACKEND>Ninja</CMAKE_BACKEND>
                 <TESTS>e3sm_developer</TESTS>
                 <BATCH_SYSTEM>none</BATCH_SYSTEM>
                 <SUPPORTED_BY>boutte3@llnl.gov</SUPPORTED_BY>
@@ -148,6 +149,7 @@ PERL5LIB                    Perl library path.
 GMAKE                       GNU-compatible make tool.
 GMAKE_J                     Number of threads for gmake.
 BATCHED_BUILD               Optional, builds will be done through batch submissions
+CMAKE_BACKEND               Optional, tells CMake which backend to use
 TESTS                       List of tests to run on the machine.
 NTEST_PARALLEL_JOBS         Number of parallel jobs for testing.
 BATCH_SYSTEM                Batch system used on the machine.
@@ -352,6 +354,8 @@ Version 3.0
                     <!-- Occurrences min: 0 max: 1-->
                     <BATCHED_BUILD></BATCHED_BUILD>
                     <!-- Occurrences min: 0 max: 1-->
+                    <CMAKE_BACKEND></CMAKE_BACKEND>
+                    <!-- Occurrences min: 0 max: 1-->
                     <TESTS></TESTS>
                     <!-- Occurrences min: 0 max: 1-->
                     <NTEST_PARALLEL_JOBS></NTEST_PARALLEL_JOBS>
@@ -525,6 +529,8 @@ Version 2.0
                     <GMAKE_J></GMAKE_J>
                     <!-- Occurrences min: 0 max: 1-->
                     <BATCHED_BUILD></BATCHED_BUILD>
+                    <!-- Occurrences min: 0 max: 1-->
+                    <CMAKE_BACKEND></CMAKE_BACKEND>
                     <!-- Occurrences min: 0 max: 1-->
                     <TESTS></TESTS>
                     <!-- Occurrences min: 0 max: 1-->


### PR DESCRIPTION
## Description

Add much better support for different cmake backends, specifically ninja.

Change list:
1) Instead of hardcoding gmake invocations, use `cmake --build .` which will flexibly work for any backend
2) Add arguments for picking a specific backend to case.build and create_test
3) env_mach will automatically add ninja to PATH if it's there.
4) Instead of using `CIME_SHAREDLIB_NINJA` as a magic var, use the env that is known to CMake (`CMAKE_GENERATOR`).
5) Add machine setting / case env var `CMAKE_BACKEND`

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that exercise my feature/fix and existing tests continue to pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding additions and changes to the documentation
