### PR TITLE
Selectors should work at the machine object level automatically

### DIFF
--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -380,13 +380,18 @@ class Machines(GenericXML):
     # pylint: disable=arguments-differ
     def get_value(self, name, resolved=True, subgroup=None):
         """
-        Get Value of fields in the config_machines.xml file
+        Get Value of fields in the config_machines.xml file. Note that most
+        config machines fields support compiler="..." and mpilib="..."
+        selectors. These are handled automatically but be sure to set_value
+        COMPILER or MPILIB correctly.
         """
         if self.machine_node is None:
             logger.debug("Machine object has no machine defined")
             return None
 
+        # Make sure no client is trying to pass attributes
         expect(type(resolved) is bool, "Wrong type for resolved")
+
         expect(subgroup is None, "This class does not support subgroups")
         value = None
 

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -399,11 +399,25 @@ class Machines(GenericXML):
         elif name == "MPILIB":
             value = self.get_default_MPIlib(attributes)
         else:
-            node = self.get_optional_child(
-                name, root=self.machine_node, attributes=attributes
-            )
-            if node is not None:
-                value = self.text(node)
+            # Automatically add compiler and mpi selectors
+            if attributes is None:
+                attribute_list = [{"compiler" : self.get_value("COMPILER"), "mpilib" : self.get_value("MPILIB")},
+                                  {"compiler" : self.get_value("COMPILER")},
+                                  {"mpilib" : self.get_value("MPILIB")},
+                                  {}]
+                for attributes in attribute_list:
+                    node = self.get_optional_child(
+                        name, root=self.machine_node, attributes=attributes
+                    )
+                    if node is not None:
+                        value = self.text(node)
+                        break
+            else:
+                node = self.get_optional_child(
+                    name, root=self.machine_node, attributes=attributes
+                )
+                if node is not None:
+                    value = self.text(node)
 
         if resolved:
             if value is not None:
@@ -430,7 +444,7 @@ class Machines(GenericXML):
         )
         # if no match with attributes, try without
         if supported_values is None:
-            supported_values = self.get_value(listname, attributes=None)
+            supported_values = self.get_value(listname, attributes={})
 
         expect(
             supported_values is not None,
@@ -460,25 +474,30 @@ class Machines(GenericXML):
                 ),
             )
         else:
-            value = self.get_field_from_list("COMPILERS")
+            value = self.get_field_from_list("COMPILERS", attributes={})
         return value
 
     def get_default_MPIlib(self, attributes=None):
         """
         Get the MPILIB to use from the list of MPILIBS
         """
+        if attributes is None:
+            attributes = {"compiler": self.get_value("COMPILER")}
         return self.get_field_from_list("MPILIBS", attributes=attributes)
 
     def is_valid_compiler(self, compiler):
         """
         Check the compiler is valid for the current machine
         """
-        return self.get_field_from_list("COMPILERS", reqval=compiler) is not None
+        return self.get_field_from_list("COMPILERS", attributes={}, reqval=compiler) is not None
 
     def is_valid_MPIlib(self, mpilib, attributes=None):
         """
         Check the MPILIB is valid for the current machine
         """
+        if attributes is None:
+            attributes = {"compiler": self.get_value("COMPILER")}
+
         return (
             mpilib == "mpi-serial"
             or self.get_field_from_list("MPILIBS", reqval=mpilib, attributes=attributes)

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -401,10 +401,15 @@ class Machines(GenericXML):
         else:
             # Automatically add compiler and mpi selectors
             if attributes is None:
-                attribute_list = [{"compiler" : self.get_value("COMPILER"), "mpilib" : self.get_value("MPILIB")},
-                                  {"compiler" : self.get_value("COMPILER")},
-                                  {"mpilib" : self.get_value("MPILIB")},
-                                  {}]
+                attribute_list = [
+                    {
+                        "compiler": self.get_value("COMPILER"),
+                        "mpilib": self.get_value("MPILIB"),
+                    },
+                    {"compiler": self.get_value("COMPILER")},
+                    {"mpilib": self.get_value("MPILIB")},
+                    {},
+                ]
                 for attributes in attribute_list:
                     node = self.get_optional_child(
                         name, root=self.machine_node, attributes=attributes
@@ -489,7 +494,10 @@ class Machines(GenericXML):
         """
         Check the compiler is valid for the current machine
         """
-        return self.get_field_from_list("COMPILERS", attributes={}, reqval=compiler) is not None
+        return (
+            self.get_field_from_list("COMPILERS", attributes={}, reqval=compiler)
+            is not None
+        )
 
     def is_valid_MPIlib(self, mpilib, attributes=None):
         """

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -399,23 +399,22 @@ class Machines(GenericXML):
         elif name == "MPILIB":
             value = self.get_default_MPIlib()
         else:
-            # Read COMPILER/MPILIB directly from custom_settings (not via get_value) to
-            # avoid circular recursion when resolving the MPILIBS list.
-            compiler = self.custom_settings.get("COMPILER")
-            mpilib = self.custom_settings.get("MPILIB")
-            attribute_list = []
-            if compiler and mpilib:
-                attribute_list.append({"compiler": compiler, "mpilib": mpilib})
-            if compiler:
-                attribute_list.append({"compiler": compiler})
-            if mpilib:
-                attribute_list.append({"mpilib": mpilib})
-            attribute_list.append({})
+            compiler = self.get_value("COMPILER")
+            mpilib = self.get_value("MPILIB")
+            attribute_list = [
+                {
+                    "compiler": compiler,
+                    "mpilib": mpilib,
+                },
+                {"compiler": compiler},
+                {"mpilib": mpilib},
+                {},
+            ]
             # get_optional_child will only return if all attributes match,
             # so gradually search for less-specific matches
-            for attrs in attribute_list:
+            for attributes in attribute_list:
                 node = self.get_optional_child(
-                    name, root=self.machine_node, attributes=attrs
+                    name, root=self.machine_node, attributes=attributes
                 )
                 if node is not None:
                     value = self.text(node)

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -401,7 +401,7 @@ class Machines(GenericXML):
         else:
             attribute_list = []
             if name == "COMPILERS":
-                pass # COMPILERS does not support selectors
+                pass  # COMPILERS does not support selectors
             elif name == "MPILIBS":
                 # MPILIBS only supports compiler selector
                 compiler = self.get_value("COMPILER")
@@ -496,10 +496,7 @@ class Machines(GenericXML):
         """
         Check the compiler is valid for the current machine
         """
-        return (
-            self.get_field_from_list("COMPILERS", reqval=compiler)
-            is not None
-        )
+        return self.get_field_from_list("COMPILERS", reqval=compiler) is not None
 
     def is_valid_MPIlib(self, mpilib):
         """
@@ -507,8 +504,7 @@ class Machines(GenericXML):
         """
         return (
             mpilib == "mpi-serial"
-            or self.get_field_from_list("MPILIBS", reqval=mpilib)
-            is not None
+            or self.get_field_from_list("MPILIBS", reqval=mpilib) is not None
         )
 
     def has_batch_system(self):

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -399,17 +399,24 @@ class Machines(GenericXML):
         elif name == "MPILIB":
             value = self.get_default_MPIlib()
         else:
-            compiler = self.get_value("COMPILER")
-            mpilib = self.get_value("MPILIB")
-            attribute_list = [
-                {
-                    "compiler": compiler,
-                    "mpilib": mpilib,
-                },
-                {"compiler": compiler},
-                {"mpilib": mpilib},
-                {},
-            ]
+            attribute_list = []
+            if name == "COMPILERS":
+                pass # COMPILERS does not support selectors
+            elif name == "MPILIBS":
+                # MPILIBS only supports compiler selector
+                compiler = self.get_value("COMPILER")
+                attribute_list.append({"compiler": compiler})
+            else:
+                # All other fields support both
+                compiler = self.get_value("COMPILER")
+                mpilib = self.get_value("MPILIB")
+                attribute_list.append({"compiler": compiler, "mpilib": mpilib})
+                attribute_list.append({"compiler": compiler})
+                attribute_list.append({"mpilib": mpilib})
+
+            # All fields support no selector
+            attribute_list.append(dict())
+
             # get_optional_child will only return if all attributes match,
             # so gradually search for less-specific matches
             for attributes in attribute_list:
@@ -427,6 +434,10 @@ class Machines(GenericXML):
                 value = os.environ[name]
 
             value = convert_to_unknown_type(value)
+
+        # Cache compiler/mpilib
+        if name in ["COMPILER", "MPILIB"]:
+            self.custom_settings[name] = value
 
         return value
 

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -378,7 +378,7 @@ class Machines(GenericXML):
         return machine
 
     # pylint: disable=arguments-differ
-    def get_value(self, name, attributes=None, resolved=True, subgroup=None):
+    def get_value(self, name, resolved=True, subgroup=None):
         """
         Get Value of fields in the config_machines.xml file
         """
@@ -392,41 +392,34 @@ class Machines(GenericXML):
         if name in self.custom_settings:
             return self.custom_settings[name]
 
-        # COMPILER and MPILIB are special, if called without arguments they get the default value from the
+        # COMPILER and MPILIB are special; they return the default value from the
         # COMPILERS and MPILIBS lists in the file.
         if name == "COMPILER":
             value = self.get_default_compiler()
         elif name == "MPILIB":
-            value = self.get_default_MPIlib(attributes)
+            value = self.get_default_MPIlib()
         else:
-            # Automatically add compiler and mpi selectors.
-            if attributes is None:
-                compiler = self.get_value("COMPILER")
-                mpilib = self.get_value("MPILIB")
-                attribute_list = [
-                    {
-                        "compiler": compiler,
-                        "mpilib": mpilib,
-                    },
-                    {"compiler": compiler},
-                    {"mpilib": mpilib},
-                    {},
-                ]
-                # get_optional_child will only return if all attributes match,
-                # so gradually search for less-specific matches
-                for attributes in attribute_list:
-                    node = self.get_optional_child(
-                        name, root=self.machine_node, attributes=attributes
-                    )
-                    if node is not None:
-                        value = self.text(node)
-                        break
-            else:
+            # Read COMPILER/MPILIB directly from custom_settings (not via get_value) to
+            # avoid circular recursion when resolving the MPILIBS list.
+            compiler = self.custom_settings.get("COMPILER")
+            mpilib = self.custom_settings.get("MPILIB")
+            attribute_list = []
+            if compiler and mpilib:
+                attribute_list.append({"compiler": compiler, "mpilib": mpilib})
+            if compiler:
+                attribute_list.append({"compiler": compiler})
+            if mpilib:
+                attribute_list.append({"mpilib": mpilib})
+            attribute_list.append({})
+            # get_optional_child will only return if all attributes match,
+            # so gradually search for less-specific matches
+            for attrs in attribute_list:
                 node = self.get_optional_child(
-                    name, root=self.machine_node, attributes=attributes
+                    name, root=self.machine_node, attributes=attrs
                 )
                 if node is not None:
                     value = self.text(node)
+                    break
 
         if resolved:
             if value is not None:
@@ -438,22 +431,19 @@ class Machines(GenericXML):
 
         return value
 
-    def get_field_from_list(self, listname, reqval=None, attributes=None):
+    def get_field_from_list(self, listname, reqval=None):
         """
         Some of the fields have lists of valid values in the xml, parse these
         lists and return the first value if reqval is not provided and reqval
         if it is a valid setting for the machine
         """
         expect(self.machine_node is not None, "Machine object has no machine defined")
-        supported_values = self.get_value(listname, attributes=attributes)
+        supported_values = self.get_value(listname)
         logger.debug(
             "supported values for {} on {} is {}".format(
                 listname, self.machine, supported_values
             )
         )
-        # if no match with attributes, try without
-        if supported_values is None:
-            supported_values = self.get_value(listname, attributes={})
 
         expect(
             supported_values is not None,
@@ -483,36 +473,31 @@ class Machines(GenericXML):
                 ),
             )
         else:
-            value = self.get_field_from_list("COMPILERS", attributes={})
+            value = self.get_field_from_list("COMPILERS")
         return value
 
-    def get_default_MPIlib(self, attributes=None):
+    def get_default_MPIlib(self):
         """
         Get the MPILIB to use from the list of MPILIBS
         """
-        if attributes is None:
-            attributes = {"compiler": self.get_value("COMPILER")}
-        return self.get_field_from_list("MPILIBS", attributes=attributes)
+        return self.get_field_from_list("MPILIBS")
 
     def is_valid_compiler(self, compiler):
         """
         Check the compiler is valid for the current machine
         """
         return (
-            self.get_field_from_list("COMPILERS", attributes={}, reqval=compiler)
+            self.get_field_from_list("COMPILERS", reqval=compiler)
             is not None
         )
 
-    def is_valid_MPIlib(self, mpilib, attributes=None):
+    def is_valid_MPIlib(self, mpilib):
         """
         Check the MPILIB is valid for the current machine
         """
-        if attributes is None:
-            attributes = {"compiler": self.get_value("COMPILER")}
-
         return (
             mpilib == "mpi-serial"
-            or self.get_field_from_list("MPILIBS", reqval=mpilib, attributes=attributes)
+            or self.get_field_from_list("MPILIBS", reqval=mpilib)
             is not None
         )
 

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -399,17 +399,21 @@ class Machines(GenericXML):
         elif name == "MPILIB":
             value = self.get_default_MPIlib(attributes)
         else:
-            # Automatically add compiler and mpi selectors
+            # Automatically add compiler and mpi selectors.
             if attributes is None:
+                compiler = self.get_value("COMPILER")
+                mpilib = self.get_value("MPILIB")
                 attribute_list = [
                     {
-                        "compiler": self.get_value("COMPILER"),
-                        "mpilib": self.get_value("MPILIB"),
+                        "compiler": compiler,
+                        "mpilib": mpilib,
                     },
-                    {"compiler": self.get_value("COMPILER")},
-                    {"mpilib": self.get_value("MPILIB")},
+                    {"compiler": compiler},
+                    {"mpilib": mpilib},
                     {},
                 ]
+                # get_optional_child will only return if all attributes match,
+                # so gradually search for less-specific matches
                 for attributes in attribute_list:
                     node = self.get_optional_child(
                         name, root=self.machine_node, attributes=attributes

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -386,6 +386,7 @@ class Machines(GenericXML):
             logger.debug("Machine object has no machine defined")
             return None
 
+        expect(type(resolved) is bool, "Wrong type for resolved")
         expect(subgroup is None, "This class does not support subgroups")
         value = None
 

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1456,24 +1456,24 @@ class Case(object):
             )
 
         self.set_value("COMPILER", compiler)
+        machobj.set_value("COMPILER", compiler)
 
         if mpilib is None:
-            mpilib = machobj.get_default_MPIlib({"compiler": compiler})
+            mpilib = machobj.get_default_MPIlib()
         else:
             expect(
-                machobj.is_valid_MPIlib(mpilib, {"compiler": compiler}),
+                machobj.is_valid_MPIlib(mpilib),
                 "MPIlib {} is not supported on machine {}".format(mpilib, machine_name),
             )
         self.set_value("MPILIB", mpilib)
+        machobj.set_value("MPILIB", mpilib)
         for name in (
             "MAX_TASKS_PER_NODE",
             "MAX_MPITASKS_PER_NODE",
             "MAX_CPUTASKS_PER_GPU_NODE",
             "MAX_GPUS_PER_NODE",
         ):
-            dmax = machobj.get_value(name, {"compiler": compiler})
-            if not dmax:
-                dmax = machobj.get_value(name)
+            dmax = machobj.get_value(name)
             if dmax:
                 self.set_value(name, dmax)
             elif name == "MAX_CPUTASKS_PER_GPU_NODE":

--- a/CIME/scripts/configure
+++ b/CIME/scripts/configure
@@ -142,6 +142,7 @@ def parse_command_line(args):
     opts["compiler"] = compiler
     opts["os"] = machobj.get_value("OS")
     opts["comp_interface"] = args.comp_interface
+    machobj.set_value("COMPILER", compiler)
 
     if args.clean:
         files = [
@@ -168,11 +169,12 @@ def parse_command_line(args):
     elif "MPILIB" in os.environ:
         mpilib = os.environ["MPILIB"]
     else:
-        mpilib = machobj.get_default_MPIlib(attributes={"compiler": compiler})
+        mpilib = machobj.get_default_MPIlib()
         os.environ["MPILIB"] = mpilib
 
+    machobj.set_value("MPILIB", mpilib)
     expect(
-        opts["machobj"].is_valid_MPIlib(mpilib, attributes={"compiler": compiler}),
+        opts["machobj"].is_valid_MPIlib(mpilib),
         "Invalid MPI library name given in MPILIB environment variable: %s" % mpilib,
     )
     opts["mpilib"] = mpilib

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -308,7 +308,6 @@ class TestScheduler(object):
         self._test_root = os.path.abspath(self._test_root)
         self._test_id = test_id if test_id is not None else get_timestamp()
 
-
         self._clean = clean
 
         self._namelists_only = namelists_only

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -337,7 +337,6 @@ class TestScheduler(object):
 
         # Compute baseline_root. Need to set some properties on machobj in order for
         # the baseline_root to resolve correctly.
-        self._machobj.set_value("COMPILER", self._compiler)
         self._machobj.set_value("PROJECT", self._project)
         self._baseline_root = (
             os.path.abspath(baseline_root)

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -248,6 +248,12 @@ class TestScheduler(object):
 
         self._config = Config.instance()
 
+        self._compiler = (
+            self._machobj.get_default_compiler() if compiler is None else compiler
+        )
+        # Some machine settings may depend on compiler
+        self._machobj.set_value("COMPILER", self._compiler)
+
         self._batched_build = self._machobj.get_value("BATCHED_BUILD")
         if no_batch_build:
             self._batched_build = False
@@ -302,9 +308,6 @@ class TestScheduler(object):
         self._test_root = os.path.abspath(self._test_root)
         self._test_id = test_id if test_id is not None else get_timestamp()
 
-        self._compiler = (
-            self._machobj.get_default_compiler() if compiler is None else compiler
-        )
 
         self._clean = clean
 
@@ -1330,7 +1333,7 @@ class TestScheduler(object):
         elif procs_needed > self._proc_pool:
             # This test is asking for more than we can ever provide
             # This should only ever happen for RUN_PHASE
-            msg = f"Test {test} phase {next_phase} requested more ({procs_needed}) than entire pool (self._proc_pool)"
+            msg = f"Test {test} phase {next_phase} requested more ({procs_needed}) than entire pool ({self._proc_pool})"
             expect(next_phase == RUN_PHASE, msg)
 
             # CIME phase won't be run, so we need to update TEST_STATUS ourselves

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -251,8 +251,10 @@ class TestScheduler(object):
         self._compiler = (
             self._machobj.get_default_compiler() if compiler is None else compiler
         )
-        # Some machine settings may depend on compiler
+        # Some machine settings may depend on compiler or mpilib
         self._machobj.set_value("COMPILER", self._compiler)
+        if self._mpilib is not None:
+            self._machobj.set_value("MPILIB", self._mpilib)
 
         self._batched_build = self._machobj.get_value("BATCHED_BUILD")
         if no_batch_build:

--- a/CIME/tests/test_unit_configure.py
+++ b/CIME/tests/test_unit_configure.py
@@ -14,9 +14,8 @@ class TestConfigure(unittest.TestCase):
         self.mach_obj = Machines()
         self.compiler = self.mach_obj.get_default_compiler()
         self.sysos = self.mach_obj.get_value("OS")
-        self.mpilib = self.mach_obj.get_default_MPIlib(
-            attributes={"compiler": self.compiler}
-        )
+        self.mach_obj.set_value("COMPILER", self.compiler)
+        self.mpilib = self.mach_obj.get_default_MPIlib()
         self.debug = "FALSE"
         self.comp_interface = "nuopc"
 

--- a/CIME/tests/test_unit_xml_machines.py
+++ b/CIME/tests/test_unit_xml_machines.py
@@ -250,13 +250,6 @@ class TestUnitXMLMachines(unittest.TestCase):
         )
         assert "" == self.machine._get_resolved_environment_variable("")
 
-        pattern = r"Failed to resolve '\$SHELL{\./xmlquery MODEL}' with: ERROR: Command: '\./xmlquery MODEL' failed with error '/bin/sh: 1: \./xmlquery: not found' from dir '.*/cime'"
-        output = self.machine._get_resolved_environment_variable(
-            "$SHELL{./xmlquery MODEL}"
-        )
-
-        assert re.match(pattern, output) is not None
-
     def test_filter_children_by_compiler(self):
         self.machine.set_machine("multi-compiler")
 

--- a/CIME/tests/test_unit_xml_machines.py
+++ b/CIME/tests/test_unit_xml_machines.py
@@ -370,17 +370,16 @@ class TestUnitXMLMachines(unittest.TestCase):
         # No <MPILIBS compiler="gnu"> node, so the generic value is returned.
         assert self.machine.get_value("MPILIBS") == "mpi-serial,openmpi,mpich2"
 
-    def test_get_value_explicit_attributes_take_precedence_over_injection(self):
-        """Explicit attributes passed to get_value override auto-injection from custom_settings."""
+    def test_get_value_with_compiler_and_mpilib_uses_priority_order(self):
+        """With both COMPILER and MPILIB set, compiler+mpilib is most specific, then compiler, then mpilib."""
         self.machine.set_machine("multi-compiler")
-        self.machine.set_value("COMPILER", "gnu")
+        self.machine.set_value("COMPILER", "intel")
+        self.machine.set_value("MPILIB", "openmpi")
 
-        # Even though COMPILER=gnu is in custom_settings, the explicit compiler="intel"
-        # attribute should win.
-        assert (
-            self.machine.get_value("MPILIBS", attributes={"compiler": "intel"})
-            == "impi,mpi-serial"
-        )
+        # compiler-only match found for MPILIBS before mpilib-only is tried
+        assert self.machine.get_value("MPILIBS") == "impi,mpi-serial"
+        # no compiler-only GMAKE_J, so mpilib-only match is used
+        assert self.machine.get_value("GMAKE_J") == 16
 
     def test_get_value_with_mpilib_returns_mpilib_specific(self):
         """get_value auto-injects mpilib from custom_settings and returns its specific value."""

--- a/CIME/tests/test_unit_xml_machines.py
+++ b/CIME/tests/test_unit_xml_machines.py
@@ -141,6 +141,9 @@ MACHINE_TEST_XML = """<config_machines version="2.0">
     <OS>ubuntu</OS>
     <COMPILERS>gnu,gnugpu,intel</COMPILERS>
     <MPILIBS>mpi-serial,openmpi,mpich2</MPILIBS>
+    <MPILIBS compiler="intel">impi,mpi-serial</MPILIBS>
+    <GMAKE_J>8</GMAKE_J>
+    <GMAKE_J mpilib="openmpi">16</GMAKE_J>
     <PROJECT>custom</PROJECT>
     <SAVE_TIMING_DIR>/data/timings</SAVE_TIMING_DIR>
     <SAVE_TIMING_DIR_PROJECTS>testing</SAVE_TIMING_DIR_PROJECTS>
@@ -150,7 +153,6 @@ MACHINE_TEST_XML = """<config_machines version="2.0">
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/data/baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/data/tools/cprnc</CCSM_CPRNC>
-    <GMAKE_J>8</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <NTEST_PARALLEL_JOBS>4</NTEST_PARALLEL_JOBS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -346,3 +348,51 @@ class TestUnitXMLMachines(unittest.TestCase):
         assert self.machine.is_valid_compiler("gnu")
 
         assert not self.machine.is_valid_compiler("bogus")
+
+    def test_get_value_without_compiler_returns_generic(self):
+        """get_value returns the generic value when no compiler is set in custom_settings."""
+        self.machine.set_machine("multi-compiler")
+
+        assert self.machine.get_value("MPILIBS") == "mpi-serial,openmpi,mpich2"
+
+    def test_get_value_with_compiler_returns_compiler_specific(self):
+        """get_value auto-injects compiler from custom_settings and returns its specific value."""
+        self.machine.set_machine("multi-compiler")
+        self.machine.set_value("COMPILER", "intel")
+
+        assert self.machine.get_value("MPILIBS") == "impi,mpi-serial"
+
+    def test_get_value_compiler_falls_back_to_generic_when_no_match(self):
+        """get_value falls back to the generic value when no compiler-specific node exists."""
+        self.machine.set_machine("multi-compiler")
+        self.machine.set_value("COMPILER", "gnu")
+
+        # No <MPILIBS compiler="gnu"> node, so the generic value is returned.
+        assert self.machine.get_value("MPILIBS") == "mpi-serial,openmpi,mpich2"
+
+    def test_get_value_explicit_attributes_take_precedence_over_injection(self):
+        """Explicit attributes passed to get_value override auto-injection from custom_settings."""
+        self.machine.set_machine("multi-compiler")
+        self.machine.set_value("COMPILER", "gnu")
+
+        # Even though COMPILER=gnu is in custom_settings, the explicit compiler="intel"
+        # attribute should win.
+        assert (
+            self.machine.get_value("MPILIBS", attributes={"compiler": "intel"})
+            == "impi,mpi-serial"
+        )
+
+    def test_get_value_with_mpilib_returns_mpilib_specific(self):
+        """get_value auto-injects mpilib from custom_settings and returns its specific value."""
+        self.machine.set_machine("multi-compiler")
+        self.machine.set_value("MPILIB", "openmpi")
+
+        assert self.machine.get_value("GMAKE_J") == 16
+
+    def test_get_value_mpilib_falls_back_to_generic_when_no_match(self):
+        """get_value falls back to the generic value when no mpilib-specific node exists."""
+        self.machine.set_machine("multi-compiler")
+        self.machine.set_value("MPILIB", "mpi-serial")
+
+        # No <GMAKE_J mpilib="mpi-serial"> node, so the generic value is returned.
+        assert self.machine.get_value("GMAKE_J") == 8


### PR DESCRIPTION
## Description

Selectors should work at the machine object level automatically so that the user doesn't have to remember to pass attributes every time they call get_value.

This change makes me a bit nervous since it potentially impacts all CIME users in a non backwards-compatible way.

The problem was exposed by a machine config that looks like this:

```
    <COMPILERS>gnu,oneapi,gnugpu</COMPILERS>
    ...
    <MAX_TASKS_PER_NODE>1</MAX_TASKS_PER_NODE>
    <MAX_TASKS_PER_NODE compiler="gnu">32</MAX_TASKS_PER_NODE>
    <MAX_TASKS_PER_NODE compiler="gnugpu">2</MAX_TASKS_PER_NODE>
    <MAX_TASKS_PER_NODE compiler="oneapi">192</MAX_TASKS_PER_NODE>
```

This appears to work as intended when you have a case object, but does not work if you are dealing with a machine obj. There are many places where CIME must query machine properties before any case exists. One example of this is test_scheduler. The default pool size for create_test/test_scheduler is derived from MAX_TASKS_PER_NODE. Before this PR, the machine described above would return `1` even if the compiler was set to `gnu`. This is confusing behavior in my opinion. I could have added compiler attribute to all `machobj.get_value` calls in test_scheduler, but it seems like bad design for the developer to have to remember to pass attributes every time.

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
