### PR TITLE
fix: report human-readable, calendar-aware elapsed time in memleak message

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,18 +43,18 @@ jobs:
         with:
           submodules: "true"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/ESMCI/cime
           tags: |
@@ -62,7 +62,7 @@ jobs:
             type=ref,event=pr,enable=${{ github.event_name == 'pull_request' }}
             type=sha,format=long
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: docker/Dockerfile
           context: .

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -1093,6 +1093,80 @@ for some of your components.
         return
 
 
+def _yyyymmdd_elapsed_str(start, end):
+    """Format elapsed model time from two YYYYMMDD-encoded date stamps.
+
+    Coupler log lines record model dates as ``YYYYMMDD`` integers (e.g.
+    ``51231`` for year 5, December 31).  Subtracting these raw integers
+    produces a nonsensical result because the encoding mixes year, month, and
+    day-of-month fields.  This function decodes both stamps and returns a
+    human-readable elapsed-time string with only the non-zero components.
+
+    ``datetime`` is intentionally not used here for two reasons:
+
+    1. **Non-Gregorian calendars.**  CIME cases can run with a 360-day or
+       NO_LEAP calendar, where dates such as February 30 (``YYYYMMDD =
+       XXXX0230``) are valid.  ``datetime.strptime`` only understands the
+       Gregorian calendar and raises ``ValueError`` on those dates.
+
+    2. **timedelta gives days, not years/months/days.**  Even on a Gregorian
+       run, ``datetime`` subtraction returns a ``timedelta`` whose only field
+       is ``days``.  Decomposing that back into years, months, and days still
+       requires knowing the calendar's day-count per month and year — so the
+       same approximation would be needed anyway.
+
+    The day-borrow and month-borrow arithmetic uses a 30-day approximation
+    because the exact model calendar (360-day, NO_LEAP, Gregorian, …) is not
+    available at this call site.  The result is intentionally approximate;
+    the message is cosmetic — it has no effect on pass/fail decisions.
+
+    Args:
+        start: Model date stamp at run start encoded as ``YYYYMMDD``
+            (int or float).
+        end: Model date stamp at run end encoded as ``YYYYMMDD``
+            (int or float).
+
+    Returns:
+        str: Human-readable elapsed time, e.g.
+            ``"4 years, 11 months, 29 days"``.  Returns ``"0 days"`` when
+            start and end are identical or the decoded difference is zero.
+
+    Examples:
+        >>> _yyyymmdd_elapsed_str(10102, 51231)
+        '4 years, 11 months, 29 days'
+        >>> _yyyymmdd_elapsed_str(10101, 20101)
+        '1 year'
+        >>> _yyyymmdd_elapsed_str(10101, 10101)
+        '0 days'
+    """
+
+    def _decode(stamp):
+        s = int(stamp)
+        return s // 10000, (s // 100) % 100, s % 100
+
+    y0, m0, d0 = _decode(start)
+    y1, m1, d1 = _decode(end)
+
+    years = y1 - y0
+    months = m1 - m0
+    days = d1 - d0
+
+    if days < 0:
+        days += 30  # 30-day approximation; calendar is unknown at this point
+        months -= 1
+    if months < 0:
+        months += 12
+        years -= 1
+
+    parts = []
+    for val, unit in ((years, "year"), (months, "month"), (days, "day")):
+        if val > 0:
+            label = unit if val == 1 else f"{unit}s"
+            parts.append(f"{val} {label}")
+
+    return ", ".join(parts) if parts else "0 days"
+
+
 def perf_check_for_memory_leak(case, tolerance):
     leak = False
     comment = ""
@@ -1105,9 +1179,6 @@ def perf_check_for_memory_leak(case, tolerance):
         except RuntimeError:
             return False, "insufficient data for memleak test"
 
-        # last day - second day, skip first day, can be too low while initializing
-        elapsed_days = int(memlist[-1][0]) - int(memlist[1][0])
-
         finalmem, originalmem = float(memlist[-1][1]), float(memlist[1][1])
 
         memdiff = -1 if originalmem <= 0 else (finalmem - originalmem) / originalmem
@@ -1119,10 +1190,13 @@ def perf_check_for_memory_leak(case, tolerance):
             leak = False
             comment = ""
         else:
+            # Skip the first sample (can be artificially low during init);
+            # report elapsed time between the second and last samples.
+            elapsed = _yyyymmdd_elapsed_str(memlist[1][0], memlist[-1][0])
             leak = True
             comment = (
-                "memleak detected, memory went from {:f} to {:f} in {:d} days".format(
-                    originalmem, finalmem, elapsed_days
+                "memleak detected, memory went from {:f} to {:f} in {:s}".format(
+                    originalmem, finalmem, elapsed
                 )
             )
 

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -850,7 +850,9 @@ class SystemTestsCommon(object):
 Expected to compare {} hist files, but only compared {}. It's possible
 that the hist_file_extension entry in config_archive.xml is not correct
 for some of your components.
-""".format(self._expected_num_cmp, num_compared)
+""".format(
+                self._expected_num_cmp, num_compared
+            )
 
         append_testlog(comments, self._orig_caseroot)
 
@@ -1345,7 +1347,9 @@ class TESTRUNPASS(FakeTest):
 echo Insta pass
 echo SUCCESSFUL TERMINATION > {rundir}/{log}.log.$LID
 cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
-""".format(rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
+""".format(
+            rundir=rundir, log=self._cpllog, root=cimeroot, case=case
+        )
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -1371,7 +1375,9 @@ if [ -z "$TESTRUNDIFF_ALTERNATE" ]; then
 else
   cp {root}/scripts/tests/cpl.hi2.nc.test {rundir}/{case}.cpl.hi.0.nc
 fi
-""".format(rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
+""".format(
+            rundir=rundir, log=self._cpllog, root=cimeroot, case=case
+        )
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -1390,7 +1396,9 @@ echo Insta pass
 echo SUCCESSFUL TERMINATION > {rundir}/{log}.log.$LID
 cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
 cp {root}/scripts/tests/cpl.hi2.nc.test {rundir}/{case}.cpl.hi.0.nc.rest
-""".format(rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
+""".format(
+            rundir=rundir, log=self._cpllog, root=cimeroot, case=case
+        )
         self._set_script(script)
         super(TESTTESTDIFF, self).build_phase(
             sharedlib_only=sharedlib_only, model_only=model_only
@@ -1416,7 +1424,9 @@ else
   echo SUCCESSFUL TERMINATION > {rundir}/{log}.log.$LID
   cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
 fi
-""".format(rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
+""".format(
+            rundir=rundir, log=self._cpllog, root=cimeroot, case=case
+        )
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -1527,7 +1537,9 @@ sleep 300
 echo Slow pass
 echo SUCCESSFUL TERMINATION > {rundir}/{log}.log.$LID
 cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
-""".format(rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
+""".format(
+            rundir=rundir, log=self._cpllog, root=cimeroot, case=case
+        )
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -1542,7 +1554,9 @@ class TESTMEMLEAKFAIL(FakeTest):
 echo Insta pass
 gunzip -c {testfile} > {rundir}/{log}.log.$LID
 cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
-""".format(testfile=testfile, rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
+""".format(
+            testfile=testfile, rundir=rundir, log=self._cpllog, root=cimeroot, case=case
+        )
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -1557,6 +1571,8 @@ class TESTMEMLEAKPASS(FakeTest):
 echo Insta pass
 gunzip -c {testfile} > {rundir}/{log}.log.$LID
 cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
-""".format(testfile=testfile, rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
+""".format(
+            testfile=testfile, rundir=rundir, log=self._cpllog, root=cimeroot, case=case
+        )
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -1093,7 +1093,49 @@ for some of your components.
         return
 
 
-def _yyyymmdd_elapsed_str(start, end):
+def _days_in_month(year, month, calendar_type="NO_LEAP"):
+    """Return the number of days in a model calendar month.
+
+    CIME cases run with one of two calendars, which share the standard
+    twelve-month Gregorian month lengths and differ only in whether February
+    gains a leap day:
+
+    * ``NO_LEAP`` (a.k.a. 365-day): every February has 28 days.
+    * ``GREGORIAN``: February has 29 days in leap years, following the
+      proleptic Gregorian leap rule.
+
+    Args:
+        year: Gregorian year the month belongs to.  Only consulted for
+            ``GREGORIAN`` February.
+        month: Month number in ``1..12``.
+        calendar_type: Model calendar name (case-insensitive).  Any value
+            other than ``GREGORIAN`` is treated as a no-leap calendar.
+
+    Returns:
+        int: Number of days in the requested month.
+
+    Examples:
+        >>> _days_in_month(1, 2, "NO_LEAP")
+        28
+        >>> _days_in_month(2000, 2, "GREGORIAN")
+        29
+        >>> _days_in_month(2001, 2, "GREGORIAN")
+        28
+    """
+    days_per_month = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    days = days_per_month[month - 1]
+
+    if (
+        month == 2
+        and str(calendar_type).upper() == "GREGORIAN"
+        and calendar.isleap(year)
+    ):
+        days = 29
+
+    return days
+
+
+def _format_elapsed_model_time(start, end, calendar_type="NO_LEAP"):
     """Format elapsed model time from two YYYYMMDD-encoded date stamps.
 
     Coupler log lines record model dates as ``YYYYMMDD`` integers (e.g.
@@ -1102,29 +1144,24 @@ def _yyyymmdd_elapsed_str(start, end):
     day-of-month fields.  This function decodes both stamps and returns a
     human-readable elapsed-time string with only the non-zero components.
 
-    ``datetime`` is intentionally not used here for two reasons:
-
-    1. **Non-Gregorian calendars.**  CIME cases can run with a 360-day or
-       NO_LEAP calendar, where dates such as February 30 (``YYYYMMDD =
-       XXXX0230``) are valid.  ``datetime.strptime`` only understands the
-       Gregorian calendar and raises ``ValueError`` on those dates.
-
-    2. **timedelta gives days, not years/months/days.**  Even on a Gregorian
-       run, ``datetime`` subtraction returns a ``timedelta`` whose only field
-       is ``days``.  Decomposing that back into years, months, and days still
-       requires knowing the calendar's day-count per month and year — so the
-       same approximation would be needed anyway.
-
-    The day-borrow and month-borrow arithmetic uses a 30-day approximation
-    because the exact model calendar (360-day, NO_LEAP, Gregorian, …) is not
-    available at this call site.  The result is intentionally approximate;
-    the message is cosmetic — it has no effect on pass/fail decisions.
+    ``datetime`` is intentionally not used here.  CIME cases run with a
+    ``NO_LEAP`` (365-day) or ``GREGORIAN`` calendar, and ``datetime`` only
+    understands the Gregorian calendar — it raises ``ValueError`` on
+    ``NO_LEAP`` dates such as ``YYYY0229`` in a non-leap year.  Even on a
+    Gregorian run, ``datetime`` subtraction yields a ``timedelta`` whose only
+    field is ``days``; decomposing that back into years/months/days still
+    requires the per-month day counts.  Both needs are met directly by
+    :func:`_days_in_month`, which is calendar-aware, so the elapsed value is
+    exact for the case's calendar rather than an approximation.
 
     Args:
         start: Model date stamp at run start encoded as ``YYYYMMDD``
             (int or float).
         end: Model date stamp at run end encoded as ``YYYYMMDD``
             (int or float).
+        calendar_type: Model calendar name (case-insensitive), typically the
+            value of the case ``CALENDAR`` variable.  Controls February's
+            length when a day-borrow crosses it.  Defaults to ``NO_LEAP``.
 
     Returns:
         str: Human-readable elapsed time, e.g.
@@ -1132,12 +1169,16 @@ def _yyyymmdd_elapsed_str(start, end):
             start and end are identical or the decoded difference is zero.
 
     Examples:
-        >>> _yyyymmdd_elapsed_str(10102, 51231)
+        >>> _format_elapsed_model_time(10102, 51231)
         '4 years, 11 months, 29 days'
-        >>> _yyyymmdd_elapsed_str(10101, 20101)
+        >>> _format_elapsed_model_time(10101, 20101)
         '1 year'
-        >>> _yyyymmdd_elapsed_str(10101, 10101)
+        >>> _format_elapsed_model_time(10101, 10101)
         '0 days'
+        >>> _format_elapsed_model_time(10205, 10301, "NO_LEAP")
+        '24 days'
+        >>> _format_elapsed_model_time(20000205, 20000301, "GREGORIAN")
+        '25 days'
     """
 
     def _decode(stamp):
@@ -1152,7 +1193,12 @@ def _yyyymmdd_elapsed_str(start, end):
     days = d1 - d0
 
     if days < 0:
-        days += 30  # 30-day approximation; calendar is unknown at this point
+        # Borrow one month, using the true length of the month immediately
+        # preceding the end month for the case's calendar.
+        borrow_year, borrow_month = y1, m1 - 1
+        if borrow_month == 0:
+            borrow_year, borrow_month = y1 - 1, 12
+        days += _days_in_month(borrow_year, borrow_month, calendar_type)
         months -= 1
     if months < 0:
         months += 12
@@ -1191,13 +1237,15 @@ def perf_check_for_memory_leak(case, tolerance):
             comment = ""
         else:
             # Skip the first sample (can be artificially low during init);
-            # report elapsed time between the second and last samples.
-            elapsed = _yyyymmdd_elapsed_str(memlist[1][0], memlist[-1][0])
+            # report elapsed time between the second and last samples using
+            # the case's calendar so month/year borrows are exact.
+            calendar_type = case.get_value("CALENDAR") or "NO_LEAP"
+            elapsed = _format_elapsed_model_time(
+                memlist[1][0], memlist[-1][0], calendar_type
+            )
             leak = True
-            comment = (
-                "memleak detected, memory went from {:f} to {:f} in {:s}".format(
-                    originalmem, finalmem, elapsed
-                )
+            comment = "memleak detected, memory went from {:f} to {:f} in {:s}".format(
+                originalmem, finalmem, elapsed
             )
 
     return leak, comment

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -41,6 +41,7 @@ from datetime import datetime, timedelta
 import glob, gzip, time, traceback, os, math, calendar
 
 from contextlib import ExitStack
+from typing import List, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
@@ -1093,7 +1094,7 @@ for some of your components.
         return
 
 
-def _days_in_month(year, month, calendar_type="NO_LEAP"):
+def _days_in_month(year: int, month: int, calendar_type: str = "NO_LEAP") -> int:
     """Return the number of days in a model calendar month.
 
     CIME cases run with one of two calendars, which share the standard
@@ -1135,7 +1136,11 @@ def _days_in_month(year, month, calendar_type="NO_LEAP"):
     return days
 
 
-def _format_elapsed_model_time(start, end, calendar_type="NO_LEAP"):
+def _format_elapsed_model_time(
+    start: Union[int, float],
+    end: Union[int, float],
+    calendar_type: str = "NO_LEAP",
+) -> str:
     """Format elapsed model time from two YYYYMMDD-encoded date stamps.
 
     Coupler log lines record model dates as ``YYYYMMDD`` integers (e.g.
@@ -1181,7 +1186,7 @@ def _format_elapsed_model_time(start, end, calendar_type="NO_LEAP"):
         '25 days'
     """
 
-    def _decode(stamp):
+    def _decode(stamp: Union[int, float]) -> Tuple[int, int, int]:
         s = int(stamp)
         return s // 10000, (s // 100) % 100, s % 100
 
@@ -1204,7 +1209,7 @@ def _format_elapsed_model_time(start, end, calendar_type="NO_LEAP"):
         months += 12
         years -= 1
 
-    parts = []
+    parts: List[str] = []
     for val, unit in ((years, "year"), (months, "month"), (days, "day")):
         if val > 0:
             label = unit if val == 1 else f"{unit}s"

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -850,9 +850,7 @@ class SystemTestsCommon(object):
 Expected to compare {} hist files, but only compared {}. It's possible
 that the hist_file_extension entry in config_archive.xml is not correct
 for some of your components.
-""".format(
-                self._expected_num_cmp, num_compared
-            )
+""".format(self._expected_num_cmp, num_compared)
 
         append_testlog(comments, self._orig_caseroot)
 
@@ -1159,6 +1157,10 @@ def _format_elapsed_model_time(
     :func:`_days_in_month`, which is calendar-aware, so the elapsed value is
     exact for the case's calendar rather than an approximation.
 
+    Day borrows walk backwards through months until ``days >= 0``; a single
+    borrow is not always sufficient (e.g. Jan 31 → Mar 1 crosses a short
+    February, requiring two borrows).
+
     Args:
         start: Model date stamp at run start encoded as ``YYYYMMDD``
             (int or float).
@@ -1184,6 +1186,8 @@ def _format_elapsed_model_time(
         '24 days'
         >>> _format_elapsed_model_time(20000205, 20000301, "GREGORIAN")
         '25 days'
+        >>> _format_elapsed_model_time(10131, 10301)
+        '29 days'
     """
 
     def _decode(stamp: Union[int, float]) -> Tuple[int, int, int]:
@@ -1198,14 +1202,19 @@ def _format_elapsed_model_time(
     days = d1 - d0
 
     if days < 0:
-        # Borrow one month, using the true length of the month immediately
-        # preceding the end month for the case's calendar.
+        # Walk backwards through months, borrowing each month's true length,
+        # until days is non-negative.  A single borrow is not always enough
+        # (e.g. Jan 31 → Mar 1 requires borrowing both Feb and Jan).
         borrow_year, borrow_month = y1, m1 - 1
         if borrow_month == 0:
             borrow_year, borrow_month = y1 - 1, 12
-        days += _days_in_month(borrow_year, borrow_month, calendar_type)
-        months -= 1
-    if months < 0:
+        while days < 0:
+            days += _days_in_month(borrow_year, borrow_month, calendar_type)
+            months -= 1
+            borrow_month -= 1
+            if borrow_month == 0:
+                borrow_year, borrow_month = borrow_year - 1, 12
+    while months < 0:
         months += 12
         years -= 1
 
@@ -1336,9 +1345,7 @@ class TESTRUNPASS(FakeTest):
 echo Insta pass
 echo SUCCESSFUL TERMINATION > {rundir}/{log}.log.$LID
 cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
-""".format(
-            rundir=rundir, log=self._cpllog, root=cimeroot, case=case
-        )
+""".format(rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -1364,9 +1371,7 @@ if [ -z "$TESTRUNDIFF_ALTERNATE" ]; then
 else
   cp {root}/scripts/tests/cpl.hi2.nc.test {rundir}/{case}.cpl.hi.0.nc
 fi
-""".format(
-            rundir=rundir, log=self._cpllog, root=cimeroot, case=case
-        )
+""".format(rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -1385,9 +1390,7 @@ echo Insta pass
 echo SUCCESSFUL TERMINATION > {rundir}/{log}.log.$LID
 cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
 cp {root}/scripts/tests/cpl.hi2.nc.test {rundir}/{case}.cpl.hi.0.nc.rest
-""".format(
-            rundir=rundir, log=self._cpllog, root=cimeroot, case=case
-        )
+""".format(rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
         self._set_script(script)
         super(TESTTESTDIFF, self).build_phase(
             sharedlib_only=sharedlib_only, model_only=model_only
@@ -1413,9 +1416,7 @@ else
   echo SUCCESSFUL TERMINATION > {rundir}/{log}.log.$LID
   cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
 fi
-""".format(
-            rundir=rundir, log=self._cpllog, root=cimeroot, case=case
-        )
+""".format(rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -1526,9 +1527,7 @@ sleep 300
 echo Slow pass
 echo SUCCESSFUL TERMINATION > {rundir}/{log}.log.$LID
 cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
-""".format(
-            rundir=rundir, log=self._cpllog, root=cimeroot, case=case
-        )
+""".format(rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -1543,9 +1542,7 @@ class TESTMEMLEAKFAIL(FakeTest):
 echo Insta pass
 gunzip -c {testfile} > {rundir}/{log}.log.$LID
 cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
-""".format(
-            testfile=testfile, rundir=rundir, log=self._cpllog, root=cimeroot, case=case
-        )
+""".format(testfile=testfile, rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -1560,8 +1557,6 @@ class TESTMEMLEAKPASS(FakeTest):
 echo Insta pass
 gunzip -c {testfile} > {rundir}/{log}.log.$LID
 cp {root}/scripts/tests/cpl.hi1.nc.test {rundir}/{case}.cpl.hi.0.nc
-""".format(
-            testfile=testfile, rundir=rundir, log=self._cpllog, root=cimeroot, case=case
-        )
+""".format(testfile=testfile, rundir=rundir, log=self._cpllog, root=cimeroot, case=case)
         self._set_script(script)
         FakeTest.build_phase(self, sharedlib_only=sharedlib_only, model_only=model_only)

--- a/CIME/tests/test_unit_system_tests.py
+++ b/CIME/tests/test_unit_system_tests.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from CIME.config import Config
 from CIME.SystemTests.system_tests_common import (
     SystemTestsCommon,
-    _yyyymmdd_elapsed_str,
+    _format_elapsed_model_time,
+    _days_in_month,
 )
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.SystemTests.system_tests_compare_n import SystemTestsCompareN
@@ -232,10 +233,10 @@ class TestUnitSystemTests:
         )
 
         perf_get_memory_list.return_value = [
-            (10102, 1000.0),   # year 1, Jan 2  – skipped (init sample)
-            (10104, 2000.0),   # year 1, Jan 4  – originalmem
-            (10106, 3000.0),   # year 1, Jan 6
-            (10108, 3000.0),   # year 1, Jan 8  – finalmem  (memdiff = 0.5 > tol)
+            (10102, 1000.0),  # year 1, Jan 2  – skipped (init sample)
+            (10104, 2000.0),  # year 1, Jan 4  – originalmem
+            (10106, 3000.0),  # year 1, Jan 6
+            (10108, 3000.0),  # year 1, Jan 8  – finalmem  (memdiff = 0.5 > tol)
         ]
 
         with tempfile.TemporaryDirectory() as tempdir:
@@ -258,6 +259,7 @@ class TestUnitSystemTests:
                 "mct",
                 None,
                 0.01,
+                "GREGORIAN",  # CALENDAR, consumed only when a leak is found
             )
 
             common = SystemTestsCommon(case)
@@ -266,9 +268,7 @@ class TestUnitSystemTests:
 
             common._check_for_memleak()
 
-            expected_comment = (
-                "memleak detected, memory went from 2000.000000 to 3000.000000 in 4 days"
-            )
+            expected_comment = "memleak detected, memory went from 2000.000000 to 3000.000000 in 4 days"
 
             common._test_status.set_status.assert_any_call(
                 "MEMLEAK", "FAIL", comments=expected_comment
@@ -292,10 +292,10 @@ class TestUnitSystemTests:
         )
 
         perf_get_memory_list.return_value = [
-            (10102, 3040.0),   # year 1, Jan 2  – skipped (init sample)
-            (10104, 3002.0),   # year 1, Jan 4  – originalmem
-            (10106, 3030.0),   # year 1, Jan 6
-            (10108, 3008.0),   # year 1, Jan 8  – finalmem  (memdiff ≈ 0.002 < tol)
+            (10102, 3040.0),  # year 1, Jan 2  – skipped (init sample)
+            (10104, 3002.0),  # year 1, Jan 4  – originalmem
+            (10106, 3030.0),  # year 1, Jan 6
+            (10108, 3008.0),  # year 1, Jan 8  – finalmem  (memdiff ≈ 0.002 < tol)
         ]
 
         with tempfile.TemporaryDirectory() as tempdir:
@@ -630,18 +630,18 @@ class TestUnitSystemTests:
 
 
 # ---------------------------------------------------------------------------
-# pytest-style tests for _yyyymmdd_elapsed_str
+# pytest-style tests for _format_elapsed_model_time
 # ---------------------------------------------------------------------------
 
 
-class TestYYYYMMDDElapsedStr:
-    """Unit tests for _yyyymmdd_elapsed_str helper.
+class TestFormatElapsedModelTime:
+    """Unit tests for _format_elapsed_model_time helper.
 
     The helper converts two YYYYMMDD-encoded model-date stamps (stored as
     float/int by the coupler-log parser) into a human-readable elapsed-time
-    string.  All calculations are approximate (30-day month borrow) because
-    the exact calendar (360-day, NO_LEAP, Gregorian …) is not available at
-    this call site and the message is cosmetic-only.
+    string.  Month/year borrows are exact for the case's calendar
+    (``NO_LEAP`` or ``GREGORIAN``), which is passed in from the case
+    ``CALENDAR`` variable; the default is ``NO_LEAP``.
     """
 
     # ------------------------------------------------------------------
@@ -650,12 +650,12 @@ class TestYYYYMMDDElapsedStr:
 
     def test_same_day_returns_zero_days(self):
         """Same start and end stamp produces '0 days'."""
-        assert _yyyymmdd_elapsed_str(10115, 10115) == "0 days"
+        assert _format_elapsed_model_time(10115, 10115) == "0 days"
 
     def test_zero_components_after_borrowing_returns_zero_days(self):
         """Edge case where all computed components are zero."""
         # year=0, month=0, day=0 after arithmetic → fall through to default
-        assert _yyyymmdd_elapsed_str(0, 0) == "0 days"
+        assert _format_elapsed_model_time(0, 0) == "0 days"
 
     # ------------------------------------------------------------------
     # days-only cases
@@ -663,15 +663,15 @@ class TestYYYYMMDDElapsedStr:
 
     def test_one_day_singular(self):
         """A one-day difference uses the singular 'day'."""
-        assert _yyyymmdd_elapsed_str(10101, 10102) == "1 day"
+        assert _format_elapsed_model_time(10101, 10102) == "1 day"
 
     def test_multiple_days_same_month(self):
         """Several days within the same month are reported correctly."""
-        assert _yyyymmdd_elapsed_str(10104, 10108) == "4 days"
+        assert _format_elapsed_model_time(10104, 10108) == "4 days"
 
     def test_many_days_no_month_borrow_needed(self):
         """Large day delta that does not require borrowing."""
-        assert _yyyymmdd_elapsed_str(10101, 10128) == "27 days"
+        assert _format_elapsed_model_time(10101, 10128) == "27 days"
 
     # ------------------------------------------------------------------
     # months-only cases
@@ -679,11 +679,11 @@ class TestYYYYMMDDElapsedStr:
 
     def test_one_month_singular(self):
         """Exactly one month difference, same day, uses singular 'month'."""
-        assert _yyyymmdd_elapsed_str(10201, 10301) == "1 month"
+        assert _format_elapsed_model_time(10201, 10301) == "1 month"
 
     def test_multiple_months_same_year(self):
         """Several months within the same year, same day-of-month."""
-        assert _yyyymmdd_elapsed_str(10101, 10601) == "5 months"
+        assert _format_elapsed_model_time(10101, 10601) == "5 months"
 
     # ------------------------------------------------------------------
     # years-only cases
@@ -691,11 +691,11 @@ class TestYYYYMMDDElapsedStr:
 
     def test_one_year_singular(self):
         """Exactly one year difference, same month/day, uses singular 'year'."""
-        assert _yyyymmdd_elapsed_str(10101, 20101) == "1 year"
+        assert _format_elapsed_model_time(10101, 20101) == "1 year"
 
     def test_multiple_years_same_month_day(self):
         """Several full years, no residual months or days."""
-        assert _yyyymmdd_elapsed_str(10101, 30101) == "2 years"
+        assert _format_elapsed_model_time(10101, 30101) == "2 years"
 
     # ------------------------------------------------------------------
     # combined-component cases
@@ -705,56 +705,87 @@ class TestYYYYMMDDElapsedStr:
         """All three components non-zero."""
         # start: year=1, month=1, day=2  →  end: year=5, month=12, day=31
         # years=4, months=11, days=29
-        assert _yyyymmdd_elapsed_str(10102, 51231) == "4 years, 11 months, 29 days"
+        assert _format_elapsed_model_time(10102, 51231) == "4 years, 11 months, 29 days"
 
     def test_all_singular_components(self):
         """Each component equals 1 (singular forms in every slot)."""
         # start: year=1, month=1, day=1  →  end: year=2, month=2, day=2
         # years=1, months=1, days=1
-        assert _yyyymmdd_elapsed_str(10101, 20202) == "1 year, 1 month, 1 day"
+        assert _format_elapsed_model_time(10101, 20202) == "1 year, 1 month, 1 day"
 
     def test_years_and_months_no_days(self):
         """Year and month components present but days component is zero."""
         # start: year=1, month=3, day=15  →  end: year=3, month=7, day=15
         # years=2, months=4, days=0
-        assert _yyyymmdd_elapsed_str(10315, 30715) == "2 years, 4 months"
+        assert _format_elapsed_model_time(10315, 30715) == "2 years, 4 months"
 
     def test_years_and_days_no_months(self):
         """Year and day components present but months component is zero."""
         # start: year=1, month=6, day=1  →  end: year=4, month=6, day=10
         # years=3, months=0, days=9
-        assert _yyyymmdd_elapsed_str(10601, 40610) == "3 years, 9 days"
+        assert _format_elapsed_model_time(10601, 40610) == "3 years, 9 days"
 
     def test_months_and_days_no_years(self):
         """Month and day components present but years component is zero."""
         # start: year=1, month=2, day=10  →  end: year=1, month=5, day=15
         # years=0, months=3, days=5
-        assert _yyyymmdd_elapsed_str(10210, 10515) == "3 months, 5 days"
+        assert _format_elapsed_model_time(10210, 10515) == "3 months, 5 days"
 
     # ------------------------------------------------------------------
     # borrow cases
     # ------------------------------------------------------------------
 
     def test_day_borrow_from_month(self):
-        """End day less than start day triggers a 30-day borrow from months."""
+        """End day less than start day borrows the true length of Feb."""
         # start: year=1, month=2, day=5  →  end: year=1, month=3, day=1
-        # raw: years=0, months=1, days=-4  →  days=26, months=0
-        assert _yyyymmdd_elapsed_str(10205, 10301) == "26 days"
+        # raw: years=0, months=1, days=-4
+        # borrow Feb (NO_LEAP → 28): days = -4 + 28 = 24, months = 0
+        assert _format_elapsed_model_time(10205, 10301) == "24 days"
 
     def test_month_borrow_from_year(self):
         """End month less than start month triggers a 12-month borrow from years."""
         # start: year=1, month=12, day=1  →  end: year=2, month=1, day=1
         # raw: years=1, months=-11, days=0  →  months=1, years=0
-        assert _yyyymmdd_elapsed_str(11201, 20101) == "1 month"
+        assert _format_elapsed_model_time(11201, 20101) == "1 month"
 
     def test_both_day_and_month_borrow(self):
         """Both day and month borrows occur in the same calculation."""
         # start: year=2, month=12, day=20  →  end: year=3, month=1, day=5
         # raw: years=1, months=-11, days=-15
-        # day borrow:  days=15, months=-12
-        # month borrow: months=0, years=0
-        # result: "15 days"
-        assert _yyyymmdd_elapsed_str(21220, 30105) == "15 days"
+        # day borrow (Dec → 31 days): days = -15 + 31 = 16, months = -12
+        # month borrow: months = 0, years = 0
+        # result: "16 days"
+        assert _format_elapsed_model_time(21220, 30105) == "16 days"
+
+    # ------------------------------------------------------------------
+    # calendar-aware borrow cases
+    # ------------------------------------------------------------------
+
+    def test_february_borrow_no_leap(self):
+        """A borrow across February on a NO_LEAP calendar uses 28 days."""
+        # start: year=4, month=2, day=5  →  end: year=4, month=3, day=1
+        # borrow Feb (NO_LEAP → 28): days = -4 + 28 = 24
+        assert _format_elapsed_model_time(40205, 40301, "NO_LEAP") == "24 days"
+
+    def test_february_borrow_gregorian_leap_year(self):
+        """A borrow across a leap-year February on GREGORIAN uses 29 days."""
+        # start: year=2000, month=2, day=5  →  end: year=2000, month=3, day=1
+        # borrow Feb (GREGORIAN, 2000 is leap → 29): days = -4 + 29 = 25
+        assert _format_elapsed_model_time(20000205, 20000301, "GREGORIAN") == "25 days"
+
+    def test_february_borrow_gregorian_non_leap_year(self):
+        """A borrow across a non-leap February on GREGORIAN uses 28 days."""
+        # start: year=2001, month=2, day=5  →  end: year=2001, month=3, day=1
+        # borrow Feb (GREGORIAN, 2001 not leap → 28): days = -4 + 28 = 24
+        assert _format_elapsed_model_time(20010205, 20010301, "GREGORIAN") == "24 days"
+
+    def test_calendar_type_is_case_insensitive(self):
+        """The calendar name is matched case-insensitively."""
+        assert _format_elapsed_model_time(20000205, 20000301, "gregorian") == "25 days"
+
+    def test_calendar_defaults_to_no_leap(self):
+        """Omitting the calendar defaults to NO_LEAP behavior."""
+        assert _format_elapsed_model_time(40205, 40301) == "24 days"
 
     # ------------------------------------------------------------------
     # float input (mirrors how the coupler log stores the stamp)
@@ -762,7 +793,10 @@ class TestYYYYMMDDElapsedStr:
 
     def test_float_stamps_accepted(self):
         """Stamps stored as float by the coupler-log parser are handled."""
-        assert _yyyymmdd_elapsed_str(10102.0, 51231.0) == "4 years, 11 months, 29 days"
+        assert (
+            _format_elapsed_model_time(10102.0, 51231.0)
+            == "4 years, 11 months, 29 days"
+        )
 
     # ------------------------------------------------------------------
     # large / long-run case
@@ -771,4 +805,53 @@ class TestYYYYMMDDElapsedStr:
     def test_century_scale_run(self):
         """Stamps spanning many decades produce a sensible result."""
         # start: year=1 Jan 1  →  end: year=100 Jan 1  →  99 years
-        assert _yyyymmdd_elapsed_str(10101, 1000101) == "99 years"
+        assert _format_elapsed_model_time(10101, 1000101) == "99 years"
+
+
+# ---------------------------------------------------------------------------
+# pytest-style tests for _days_in_month
+# ---------------------------------------------------------------------------
+
+
+class TestDaysInMonth:
+    """Unit tests for the calendar-aware _days_in_month helper."""
+
+    def test_thirty_one_day_month(self):
+        """January always has 31 days."""
+        assert _days_in_month(2000, 1, "GREGORIAN") == 31
+
+    def test_thirty_day_month(self):
+        """April always has 30 days."""
+        assert _days_in_month(2000, 4, "GREGORIAN") == 30
+
+    def test_february_no_leap_calendar(self):
+        """February is always 28 days on a NO_LEAP calendar, even a leap year."""
+        assert _days_in_month(2000, 2, "NO_LEAP") == 28
+
+    def test_february_gregorian_leap_year(self):
+        """February gains a day in a Gregorian leap year."""
+        assert _days_in_month(2000, 2, "GREGORIAN") == 29
+
+    def test_february_gregorian_non_leap_year(self):
+        """February has 28 days in a Gregorian non-leap year."""
+        assert _days_in_month(2001, 2, "GREGORIAN") == 28
+
+    def test_february_gregorian_century_non_leap(self):
+        """A non-400 century year is not a leap year under the Gregorian rule."""
+        assert _days_in_month(1900, 2, "GREGORIAN") == 28
+
+    def test_february_gregorian_400_year_leap(self):
+        """A year divisible by 400 is a leap year under the Gregorian rule."""
+        assert _days_in_month(2000, 2, "GREGORIAN") == 29
+
+    def test_calendar_case_insensitive(self):
+        """Calendar name comparison is case-insensitive."""
+        assert _days_in_month(2000, 2, "gregorian") == 29
+
+    def test_unknown_calendar_treated_as_no_leap(self):
+        """Any non-GREGORIAN calendar name falls back to no-leap behavior."""
+        assert _days_in_month(2000, 2, "360_day") == 28
+
+    def test_default_calendar_is_no_leap(self):
+        """Omitting the calendar defaults to no-leap February."""
+        assert _days_in_month(2000, 2) == 28

--- a/CIME/tests/test_unit_system_tests.py
+++ b/CIME/tests/test_unit_system_tests.py
@@ -5,12 +5,14 @@ import tempfile
 import gzip
 import re
 from re import A
-import unittest
 from unittest import mock
 from pathlib import Path
 
 from CIME.config import Config
-from CIME.SystemTests.system_tests_common import SystemTestsCommon
+from CIME.SystemTests.system_tests_common import (
+    SystemTestsCommon,
+    _yyyymmdd_elapsed_str,
+)
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.SystemTests.system_tests_compare_n import SystemTestsCompareN
 
@@ -108,7 +110,7 @@ def create_mock_case(tempdir, idx=None, cpllog_data=None):
     return case, caseroot, baseline_root, run_dir
 
 
-class TestUnitSystemTests(unittest.TestCase):
+class TestUnitSystemTests:
     @mock.patch("CIME.SystemTests.system_tests_common.load_coupler_customization")
     @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
     @mock.patch("CIME.SystemTests.system_tests_common.perf_get_memory_list")
@@ -176,8 +178,8 @@ class TestUnitSystemTests(unittest.TestCase):
         )
 
         perf_get_memory_list.return_value = [
-            (1, 1000.0),
-            (2, 0),
+            (10102, 1000.0),  # year 1, Jan 2
+            (10104, 0),  # year 1, Jan 4  (originalmem=0 → insufficient data)
         ]
 
         with tempfile.TemporaryDirectory() as tempdir:
@@ -230,10 +232,10 @@ class TestUnitSystemTests(unittest.TestCase):
         )
 
         perf_get_memory_list.return_value = [
-            (1, 1000.0),
-            (2, 2000.0),
-            (3, 3000.0),
-            (4, 3000.0),
+            (10102, 1000.0),   # year 1, Jan 2  – skipped (init sample)
+            (10104, 2000.0),   # year 1, Jan 4  – originalmem
+            (10106, 3000.0),   # year 1, Jan 6
+            (10108, 3000.0),   # year 1, Jan 8  – finalmem  (memdiff = 0.5 > tol)
         ]
 
         with tempfile.TemporaryDirectory() as tempdir:
@@ -264,7 +266,9 @@ class TestUnitSystemTests(unittest.TestCase):
 
             common._check_for_memleak()
 
-            expected_comment = "memleak detected, memory went from 2000.000000 to 3000.000000 in 2 days"
+            expected_comment = (
+                "memleak detected, memory went from 2000.000000 to 3000.000000 in 4 days"
+            )
 
             common._test_status.set_status.assert_any_call(
                 "MEMLEAK", "FAIL", comments=expected_comment
@@ -288,10 +292,10 @@ class TestUnitSystemTests(unittest.TestCase):
         )
 
         perf_get_memory_list.return_value = [
-            (1, 3040.0),
-            (2, 3002.0),
-            (3, 3030.0),
-            (4, 3008.0),
+            (10102, 3040.0),   # year 1, Jan 2  – skipped (init sample)
+            (10104, 3002.0),   # year 1, Jan 4  – originalmem
+            (10106, 3030.0),   # year 1, Jan 6
+            (10108, 3008.0),   # year 1, Jan 8  – finalmem  (memdiff ≈ 0.002 < tol)
         ]
 
         with tempfile.TemporaryDirectory() as tempdir:
@@ -623,3 +627,148 @@ class TestUnitSystemTests(unittest.TestCase):
         _ = SystemTestsCompareN(case, something="random")
 
         SystemTestsCompareN._get_caseroots = orig
+
+
+# ---------------------------------------------------------------------------
+# pytest-style tests for _yyyymmdd_elapsed_str
+# ---------------------------------------------------------------------------
+
+
+class TestYYYYMMDDElapsedStr:
+    """Unit tests for _yyyymmdd_elapsed_str helper.
+
+    The helper converts two YYYYMMDD-encoded model-date stamps (stored as
+    float/int by the coupler-log parser) into a human-readable elapsed-time
+    string.  All calculations are approximate (30-day month borrow) because
+    the exact calendar (360-day, NO_LEAP, Gregorian …) is not available at
+    this call site and the message is cosmetic-only.
+    """
+
+    # ------------------------------------------------------------------
+    # same-date / zero cases
+    # ------------------------------------------------------------------
+
+    def test_same_day_returns_zero_days(self):
+        """Same start and end stamp produces '0 days'."""
+        assert _yyyymmdd_elapsed_str(10115, 10115) == "0 days"
+
+    def test_zero_components_after_borrowing_returns_zero_days(self):
+        """Edge case where all computed components are zero."""
+        # year=0, month=0, day=0 after arithmetic → fall through to default
+        assert _yyyymmdd_elapsed_str(0, 0) == "0 days"
+
+    # ------------------------------------------------------------------
+    # days-only cases
+    # ------------------------------------------------------------------
+
+    def test_one_day_singular(self):
+        """A one-day difference uses the singular 'day'."""
+        assert _yyyymmdd_elapsed_str(10101, 10102) == "1 day"
+
+    def test_multiple_days_same_month(self):
+        """Several days within the same month are reported correctly."""
+        assert _yyyymmdd_elapsed_str(10104, 10108) == "4 days"
+
+    def test_many_days_no_month_borrow_needed(self):
+        """Large day delta that does not require borrowing."""
+        assert _yyyymmdd_elapsed_str(10101, 10128) == "27 days"
+
+    # ------------------------------------------------------------------
+    # months-only cases
+    # ------------------------------------------------------------------
+
+    def test_one_month_singular(self):
+        """Exactly one month difference, same day, uses singular 'month'."""
+        assert _yyyymmdd_elapsed_str(10201, 10301) == "1 month"
+
+    def test_multiple_months_same_year(self):
+        """Several months within the same year, same day-of-month."""
+        assert _yyyymmdd_elapsed_str(10101, 10601) == "5 months"
+
+    # ------------------------------------------------------------------
+    # years-only cases
+    # ------------------------------------------------------------------
+
+    def test_one_year_singular(self):
+        """Exactly one year difference, same month/day, uses singular 'year'."""
+        assert _yyyymmdd_elapsed_str(10101, 20101) == "1 year"
+
+    def test_multiple_years_same_month_day(self):
+        """Several full years, no residual months or days."""
+        assert _yyyymmdd_elapsed_str(10101, 30101) == "2 years"
+
+    # ------------------------------------------------------------------
+    # combined-component cases
+    # ------------------------------------------------------------------
+
+    def test_years_months_days_all_present(self):
+        """All three components non-zero."""
+        # start: year=1, month=1, day=2  →  end: year=5, month=12, day=31
+        # years=4, months=11, days=29
+        assert _yyyymmdd_elapsed_str(10102, 51231) == "4 years, 11 months, 29 days"
+
+    def test_all_singular_components(self):
+        """Each component equals 1 (singular forms in every slot)."""
+        # start: year=1, month=1, day=1  →  end: year=2, month=2, day=2
+        # years=1, months=1, days=1
+        assert _yyyymmdd_elapsed_str(10101, 20202) == "1 year, 1 month, 1 day"
+
+    def test_years_and_months_no_days(self):
+        """Year and month components present but days component is zero."""
+        # start: year=1, month=3, day=15  →  end: year=3, month=7, day=15
+        # years=2, months=4, days=0
+        assert _yyyymmdd_elapsed_str(10315, 30715) == "2 years, 4 months"
+
+    def test_years_and_days_no_months(self):
+        """Year and day components present but months component is zero."""
+        # start: year=1, month=6, day=1  →  end: year=4, month=6, day=10
+        # years=3, months=0, days=9
+        assert _yyyymmdd_elapsed_str(10601, 40610) == "3 years, 9 days"
+
+    def test_months_and_days_no_years(self):
+        """Month and day components present but years component is zero."""
+        # start: year=1, month=2, day=10  →  end: year=1, month=5, day=15
+        # years=0, months=3, days=5
+        assert _yyyymmdd_elapsed_str(10210, 10515) == "3 months, 5 days"
+
+    # ------------------------------------------------------------------
+    # borrow cases
+    # ------------------------------------------------------------------
+
+    def test_day_borrow_from_month(self):
+        """End day less than start day triggers a 30-day borrow from months."""
+        # start: year=1, month=2, day=5  →  end: year=1, month=3, day=1
+        # raw: years=0, months=1, days=-4  →  days=26, months=0
+        assert _yyyymmdd_elapsed_str(10205, 10301) == "26 days"
+
+    def test_month_borrow_from_year(self):
+        """End month less than start month triggers a 12-month borrow from years."""
+        # start: year=1, month=12, day=1  →  end: year=2, month=1, day=1
+        # raw: years=1, months=-11, days=0  →  months=1, years=0
+        assert _yyyymmdd_elapsed_str(11201, 20101) == "1 month"
+
+    def test_both_day_and_month_borrow(self):
+        """Both day and month borrows occur in the same calculation."""
+        # start: year=2, month=12, day=20  →  end: year=3, month=1, day=5
+        # raw: years=1, months=-11, days=-15
+        # day borrow:  days=15, months=-12
+        # month borrow: months=0, years=0
+        # result: "15 days"
+        assert _yyyymmdd_elapsed_str(21220, 30105) == "15 days"
+
+    # ------------------------------------------------------------------
+    # float input (mirrors how the coupler log stores the stamp)
+    # ------------------------------------------------------------------
+
+    def test_float_stamps_accepted(self):
+        """Stamps stored as float by the coupler-log parser are handled."""
+        assert _yyyymmdd_elapsed_str(10102.0, 51231.0) == "4 years, 11 months, 29 days"
+
+    # ------------------------------------------------------------------
+    # large / long-run case
+    # ------------------------------------------------------------------
+
+    def test_century_scale_run(self):
+        """Stamps spanning many decades produce a sensible result."""
+        # start: year=1 Jan 1  →  end: year=100 Jan 1  →  99 years
+        assert _yyyymmdd_elapsed_str(10101, 1000101) == "99 years"

--- a/CIME/tests/test_unit_system_tests.py
+++ b/CIME/tests/test_unit_system_tests.py
@@ -807,6 +807,73 @@ class TestFormatElapsedModelTime:
         # start: year=1 Jan 1  →  end: year=100 Jan 1  →  99 years
         assert _format_elapsed_model_time(10101, 1000101) == "99 years"
 
+    # ------------------------------------------------------------------
+    # multi-borrow cases (regression for single-borrow bug)
+    # ------------------------------------------------------------------
+
+    def test_multi_borrow_jan31_to_mar1_no_leap(self):
+        """Jan 31 → Mar 1 requires borrowing both Feb and Jan (NO_LEAP).
+
+        Single-borrow bug: borrowing Feb(28) leaves days = -30 + 28 = -2,
+        still negative.  A second borrow of Jan(31) gives days = -2 + 31 = 29.
+        months goes -2 then -3; month normalisation: months=9, years=-1 → but
+        years was 0, so the loop continues; total months=-3+12=9, years=-1.
+        Wait — let us re-derive:
+
+        start = 10131 → y=1, m=1, d=31
+        end   = 10301 → y=1, m=3, d=1
+        raw: years=0, months=2, days=-30
+
+        Borrow 1 (Feb=28): days=-2, months=1
+        Borrow 2 (Jan=31): days=29, months=0  → loop exits
+        months=0 ≥ 0, no month normalisation needed.
+
+        Result: 0 years, 0 months, 29 days → "29 days"
+        """
+        assert _format_elapsed_model_time(10131, 10301) == "29 days"
+
+    def test_multi_borrow_jan31_to_mar1_gregorian_leap(self):
+        """Jan 31 → Mar 1 on GREGORIAN leap year (Feb=29) → 30 days.
+
+        start = 20000131 → y=2000, m=1, d=31
+        end   = 20000301 → y=2000, m=3, d=1
+        raw: years=0, months=2, days=-30
+
+        Borrow 1 (Feb 2000=29): days=-1, months=1
+        Borrow 2 (Jan=31):      days=30, months=0  → loop exits
+
+        Result: "30 days"
+        """
+        assert _format_elapsed_model_time(20000131, 20000301, "GREGORIAN") == "30 days"
+
+    def test_multi_borrow_jan31_to_mar1_gregorian_non_leap(self):
+        """Jan 31 → Mar 1 on GREGORIAN non-leap year (Feb=28) → 29 days.
+
+        start = 20010131 → y=2001, m=1, d=31
+        end   = 20010301 → y=2001, m=3, d=1
+        raw: years=0, months=2, days=-30
+
+        Borrow 1 (Feb 2001=28): days=-2, months=1
+        Borrow 2 (Jan=31):      days=29, months=0  → loop exits
+
+        Result: "29 days"
+        """
+        assert _format_elapsed_model_time(20010131, 20010301, "GREGORIAN") == "29 days"
+
+    def test_multi_borrow_across_year_boundary(self):
+        """Multi-borrow spanning a year boundary produces correct output.
+
+        start = 11215 → y=1, m=12, d=15
+        end   = 20210 → y=2, m=2,  d=10
+        raw: years=1, months=-10, days=-5
+
+        Borrow 1 (Jan=31): days=26, months=-11
+        months < 0: months=1, years=0
+
+        Result: "1 month, 26 days"
+        """
+        assert _format_elapsed_model_time(11215, 20210) == "1 month, 26 days"
+
 
 # ---------------------------------------------------------------------------
 # pytest-style tests for _days_in_month


### PR DESCRIPTION
## Description

Fixes #5007.

The memory-leak check in `CIME/SystemTests/system_tests_common.py` reported elapsed model time in "days" using arithmetic that was not actually days. It subtracted two `YYYYMMDD`-encoded model-date stamps directly, so a 5-year run reported nonsense like `41129 days` (the message mixed years ×10000, months ×100, and day-of-month).

### Root cause

`perf_get_memory_list` stores the model date as `float(YYYYMMDD)` (e.g. `51231.0`), and `perf_check_for_memory_leak` differenced the raw stamps:

```python
elapsed_days = int(memlist[-1][0]) - int(memlist[1][0])  # 51231 - 10102 = 41129
```

This is cosmetic only — the pass/fail decision uses `finalmem/originalmem` and the tolerance ratio, both unaffected — but the message is misleading and can send developers debugging in the wrong direction.

### Fix

- Decode the `YYYYMMDD` stamp into `(year, month, day)` and report elapsed time in years/months/days, dropping zero components, e.g. `memleak detected, memory went from 1499.740000 to 1578.320000 in 4 years, 11 months, 29 days`.
- Make the arithmetic **calendar-aware**: the case `CALENDAR` variable (`NO_LEAP` or `GREGORIAN`) is threaded through so a day-borrow uses the true length of the preceding month (including the Gregorian leap-year rule) rather than a flat 30-day approximation.
- New helper `_days_in_month(year, month, calendar_type)`.
- Renamed the formatting helper to `_format_elapsed_model_time` (describes intent rather than input encoding).

### Tests

- `TestFormatElapsedModelTime`: singular/plural units, every component combination, day/month/year borrows, float stamps, and century-scale runs.
- Calendar-specific cases: `NO_LEAP` February, Gregorian leap / non-leap / century / 400-year February, and case-insensitive calendar names.
- New `TestDaysInMonth` class covering 30/31-day months and all February edge cases.
- Updated the memleak integration test to supply `CALENDAR` and assert the new message.

All `test_unit_system_tests.py` tests pass (the 2 pre-existing `test_generate_baseline` failures are unrelated — they spawn a real subprocess). Doctests pass; `black` (22.3.0) and `pylint` (4.0.4) clean.

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that exercise my feature/fix and existing tests continue to pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
