### PR TITLE
fix(archive): anchor component name when matching history files

### DIFF
--- a/CIME/XML/archive_base.py
+++ b/CIME/XML/archive_base.py
@@ -157,9 +157,12 @@ class ArchiveBase(GenericXML):
         for ext in extensions:
             if ext.endswith("$") and has_suffix:
                 ext = ext[:-1]
-            # Anchor the component name at a filename boundary. Without this, a
-            # component name that happens to be a substring of another one (e.g.
-            # "eam" inside "scream") matches the other component's history files.
+            # The first part of this regex forces the model name to appear
+            # either at the start of the string or following a '.', '-' or '_'.
+            # Without this, re.search would find the model name anywhere in the
+            # file name, so a model whose name is a substring of another model's
+            # name (e.g. "eam" within "scream") would match the other model's
+            # history files.
             string = r"(?:^|[\.\-_])" + model + r"\d?_?(\d{4})?(_d\d{2})?\." + ext
             if has_suffix:
                 if not suffix in string:

--- a/CIME/XML/archive_base.py
+++ b/CIME/XML/archive_base.py
@@ -157,7 +157,10 @@ class ArchiveBase(GenericXML):
         for ext in extensions:
             if ext.endswith("$") and has_suffix:
                 ext = ext[:-1]
-            string = model + r"\d?_?(\d{4})?(_d\d{2})?\." + ext
+            # Anchor the component name at a filename boundary. Without this, a
+            # component name that happens to be a substring of another one (e.g.
+            # "eam" inside "scream") matches the other component's history files.
+            string = r"(?:^|[\.\-_])" + model + r"\d?_?(\d{4})?(_d\d{2})?\." + ext
             if has_suffix:
                 if not suffix in string:
                     string += r"\." + suffix + "$"

--- a/CIME/tests/test_unit_xml_archive_base.py
+++ b/CIME/tests/test_unit_xml_archive_base.py
@@ -34,6 +34,46 @@ EXCLUDE_TEST_CONFIG = """<components version="2.0">
   </comp_archive_spec>
 </components>"""
 
+# "eam" is a substring of "scream", so both specs are candidates for either
+# component's files unless the component name is anchored at a name boundary.
+SUBSTRING_TEST_CONFIG = r"""<components version="2.0">
+  <comp_archive_spec compname="eam" compclass="atm">
+    <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
+  </comp_archive_spec>
+  <comp_archive_spec compname="scream" compclass="atm">
+    <hist_file_extension>(.*\.)?h\.(?!rhist\.).*\.nc$</hist_file_extension>
+  </comp_archive_spec>
+</components>"""
+
+
+def test_component_name_is_not_matched_as_substring(tmp_path):
+    """History files of one component must not match a substring component name."""
+    archiver = ArchiveBase()
+    archiver.read_fd(io.StringIO(SUBSTRING_TEST_CONFIG))
+
+    eam_file = "casename.eam.h0.0001-01.nc"
+    scream_file = "casename.scream.h.AVERAGE.nmonths_x1.0001-01.nc"
+    for name in (eam_file, scream_file):
+        (tmp_path / name).touch()
+
+    assert archiver.get_all_hist_files("casename", "eam", str(tmp_path)) == [eam_file]
+    assert archiver.get_all_hist_files("casename", "scream", str(tmp_path)) == [
+        scream_file
+    ]
+
+
+def test_component_name_at_start_of_filename(tmp_path):
+    """A filename may start with the component name instead of the casename."""
+    archiver = ArchiveBase()
+    archiver.read_fd(io.StringIO(SUBSTRING_TEST_CONFIG))
+
+    scream_file = "scream.h.AVERAGE.nmonths_x1.0001-01.nc"
+    (tmp_path / scream_file).touch()
+
+    assert archiver.get_all_hist_files("casename", "scream", str(tmp_path)) == [
+        scream_file
+    ]
+
 
 class TestXMLArchiveBase(unittest.TestCase):
     @contextmanager


### PR DESCRIPTION
## Problem

`ArchiveBase.get_all_hist_files()` builds its match regex by concatenating the component name directly onto the extension pattern:

```python
string = model + r"\d?_?(\d{4})?(_d\d{2})?\." + ext
```

and then uses `re.search`, so the component name matches anywhere in the filename — including *inside another component's name*. The concrete case is E3SM's atmosphere components: `eam` is a substring of `scream`, so the `eam` spec matches EAMxx history files:

```python
>>> archiver.get_all_hist_files("casename", "eam", rundir)
['casename.scream.h.AVERAGE.nmonths_x1.0001-01.nc']   # not an eam file
```

`casename.scream.h...` contains `eam` (in `scr-eam`) followed by `.`, and `eam`'s extension `h\d*.*\.nc$` then matches the rest.

In a real case only one atmosphere spec is loaded, so this does not corrupt production archiving. Where it does bite is anywhere several specs are in play at once — `test_st_archive`, which loads every `comp_archive_spec` in the model — so a component's spec can silently "cover" for another component's broken or missing pattern, and the test passes when it should not. That is exactly what happened in E3SM: a wrong `hist_file_extension` for `scream` went unnoticed because `eam`'s pattern matched the files instead (E3SM-Project/E3SM#6190, E3SM-Project/E3SM#8589).

## Fix

Anchor the component name at a filename boundary — start of name, or preceded by `.`, `-`, or `_`:

```python
string = r"(?:^|[\.\-_])" + model + r"\d?_?(\d{4})?(_d\d{2})?\." + ext
```

The leading `^` alternative keeps the existing `f.startswith(model)` case working, where a file is named after the component rather than the case. The added group is non-capturing, so the existing `(\d{4})?` / `(_d\d{2})?` group numbering is unchanged (nothing reads those groups here, but it keeps the diff behavior-neutral).

Every separator that appears before a component name in the naming conventions I could find is covered: `casename.eam.h0…`, `casename.eam_0002.e…`, `casename.clm2_0002.h0…`, `ga0xnw.mom6.frc…`, `casename.mpaso.hist.am…`, and the long test-name form `…C.fake_testing_only_20160816_164150-20160816_164240.cpl.h.nc`.

## Tests

Two new tests in `CIME/tests/test_unit_xml_archive_base.py`, written as pytest functions per `AGENTS.md`:

- `test_component_name_is_not_matched_as_substring` — with both an `eam` and a `scream` spec loaded, each component returns only its own history file. **Fails on master**, passes with this change.
- `test_component_name_at_start_of_filename` — covers the `^` alternative, i.e. a file named after the component instead of the case.

Verified locally:

- `pytest CIME/tests/test_unit_xml_archive_base.py CIME/tests/test_unit_case_st_archive.py` — 14 passed.
- `pytest CIME/tests/ -k unit` — 486 passed, 15 skipped, 3 failed; the same 3 (`test_unit_doctest::test_lib_docs` and two `test_unit_system_tests::test_generate_baseline*`) fail identically on unmodified master in this environment, so they are pre-existing and unrelated.
- `black --check` clean on both files.

## Note

`_get_extension()` in the same module builds its regex the same way and has the same substring exposure. I left it alone to keep this change small, since it is only reached with a single component's model name at a time; happy to extend it here if you would prefer both fixed together.

_Analysis and patch produced by Claude (Claude Code)._
