### PR TITLE
feat(build): support Depends.OS.COMPILER (e.g. Depends.Darwin.gnu) in configure and Makefile

### DIFF
--- a/CIME/BuildTools/configure.py
+++ b/CIME/BuildTools/configure.py
@@ -102,7 +102,11 @@ def configure(
                 fd.write(output)
 
     copy_depends_files(
-        machobj.get_machine_name(), machobj.machines_dir, output_dir, compiler
+        machobj.get_machine_name(),
+        machobj.machines_dir,
+        output_dir,
+        compiler,
+        sysos,
     )
     generate_env_mach_specific(
         output_dir,
@@ -118,7 +122,7 @@ def configure(
     )
 
 
-def copy_depends_files(machine_name, machines_dir, output_dir, compiler):
+def copy_depends_files(machine_name, machines_dir, output_dir, compiler, os_name):
     """
     Copy any system or compiler Depends files if they do not exist in the output directory
     If there is a match for Depends.machine_name.compiler copy that and ignore the others
@@ -126,7 +130,8 @@ def copy_depends_files(machine_name, machines_dir, output_dir, compiler):
     # Note, the cmake build system does not stop if Depends.mach.compiler.cmake is found
     makefiles_done = False
     both = "{}.{}".format(machine_name, compiler)
-    for suffix in [both, machine_name, compiler]:
+    suffixes = [both, machine_name, "{}.{}".format(os_name, compiler), os_name, compiler]
+    for suffix in suffixes:
         for extra_suffix in ["", ".cmake"]:
             if extra_suffix == "" and makefiles_done:
                 continue

--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -1074,7 +1074,7 @@ realclean: clean cleancsmshare cleanpio cleangptl
 ifneq ($(MAKECMDGOALS), db_files)
 ifneq ($(MAKECMDGOALS), db_flags)
 ifeq (,$(findstring clean,$(MAKECMDGOALS)))
-    -include Depends $(CASEROOT)/Depends.$(COMPILER) $(CASEROOT)/Depends.$(MACH) $(CASEROOT)/Depends.$(MACH).$(COMPILER)
+    -include Depends $(CASEROOT)/Depends.$(COMPILER) $(CASEROOT)/Depends.$(MACH) $(CASEROOT)/Depends.$(MACH).$(COMPILER) $(CASEROOT)/Depends.$(OS) $(CASEROOT)/Depends.$(OS).$(COMPILER)
 endif
 endif
 endif

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -182,7 +182,7 @@ def _create_macros_cmake(
                     "and should be replaced with the form MACHINE_COMPILER.cmake\n"
                 )
 
-    copy_depends_files(mach, mach_obj.machines_dir, caseroot, compiler)
+    copy_depends_files(mach, mach_obj.machines_dir, caseroot, compiler, os_)
 
 
 ###############################################################################

--- a/CIME/tests/test_unit_case_setup.py
+++ b/CIME/tests/test_unit_case_setup.py
@@ -56,7 +56,7 @@ class TestCaseSetup(unittest.TestCase):
             assert os.path.exists(os.path.join(case_path, "cmake_macros", "test.cmake"))
 
             copy_depends_files.assert_called_with(
-                "test", machines_path, case_path, "gnu-test"
+                "test", machines_path, case_path, "gnu-test", machine_mock.get_value.return_value
             )
 
     @mock.patch("CIME.case.case_setup._create_macros_cmake")


### PR DESCRIPTION
### Description of changes
Enhances CIME's `Depends` file resolution to automatically detect and load OS-level `Depends` files (e.g., `Depends.Darwin.gnu` or `Depends.Darwin`):
1. **`CIME/BuildTools/configure.py`:** Adds `os_name` as a required 5th positional argument to `copy_depends_files` so it checks for `Depends.<OS>.<COMPILER>` and `Depends.<OS>` in `machines_dir` and copies them to `<CASEROOT>`.
2. **`CIME/case/case_setup.py`:** Passes `os_` as the 5th positional argument during `_create_macros_cmake`.
3. **`CIME/Tools/Makefile`:** Adds `$(CASEROOT)/Depends.$(OS)` and `$(CASEROOT)/Depends.$(OS).$(COMPILER)` to the Makefile `-include` list.

### Specific notes

**Contributors other than yourself, if any:**
- @billsacks
- @johnpaulalex

**Linked issues addressed, if any:**
<!-- Note: Only refer to relevant GitHub issues here. Always use direct fully qualified links. Do NOT reference or list other PRs/pull requests. -->
- None

**Description of generative AI usage:**
- Google Antigravity was used to write the code and tests, followed by human-guided verification.

### Answer Changes & Scientific Impact
- [x] **Bit-for-Bit (B4B)** with baseline master
- [ ] **Roundoff-level differences only**
- [ ] **Expected Answer Changes (ECA)**

### User Interface & Namelist Changes
- **Namelist / Defaults modified?** No
- **XML / Build script changes?** Yes (`CIME/BuildTools/configure.py`, `CIME/case/case_setup.py`, `CIME/Tools/Makefile`)

### Testing planned or performed, if any:
- [x] Executed python unit tests (`python3 -m unittest CIME/tests/test_unit_case_setup.py`).
- [x] Executed build and verified cmake macro compilation under debug configurations on macOS.

**CTSM / CESM baseline hash-tag:** `8961a1142`
**PR branch hash-tag:** `a24867cb2`

### Requirements before merge:
- [x] The code in this PR branch builds with no errors.
- [x] The code in this PR branch runs with no errors.
- [x] In-code documentation and Fortran docstrings updated.
- [x] This PR either (a) does not create a need to update documentation or (b) includes required documentation updates. **Which?:** (a) Build infrastructure modification; no documentation updates required.