### PR TITLE
feat(cime): Add lock_on_restart attribute support and locked file validation

### DIFF
--- a/CIME/XML/entry_id.py
+++ b/CIME/XML/entry_id.py
@@ -239,6 +239,22 @@ class EntryID(GenericXML):
     def get_nodes_by_id(self, vid):
         return self.scan_children("entry", {"id": vid})
 
+    def is_lock_on_restart(self, vid_or_node):
+        """Check if an entry definition specifies lock_on_restart='true' via attribute or child element."""
+        if isinstance(vid_or_node, str):
+            node = self.scan_optional_child("entry", {"id": vid_or_node})
+        else:
+            node = vid_or_node
+        if node is None:
+            return False
+
+        val = (
+            self.get(node, "lock_on_restart")
+            or self.get_element_text("lock_on_restart", root=node)
+            or ""
+        )
+        return val.lower() == "true"
+
     def _set_valid_values(self, node, new_valid_values):
         old_vv = self._get_valid_values(node)
         if old_vv is None:

--- a/CIME/case/case_run.py
+++ b/CIME/case/case_run.py
@@ -10,7 +10,7 @@ from CIME.utils import run_sub_or_cmd, safe_copy, model_log
 from CIME.utils import batch_jobid, is_comp_standalone
 from CIME.status import append_status, run_and_log_case_status
 from CIME.get_timing import get_timing
-from CIME.locked_files import check_lockedfiles
+from CIME.locked_files import check_lockedfiles, lock_file, is_locked
 
 import shutil, time, sys, os, glob
 
@@ -42,6 +42,10 @@ def _pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
 
     if case.get_value("EXTERNAL_WORKFLOW"):
         skip = "env_batch"
+
+    # Lock env_run.xml initial state prior to first run segment or setup
+    if not is_locked("env_run.xml", caseroot) or not case.get_value("CONTINUE_RUN"):
+        lock_file("env_run.xml", caseroot)
 
     check_lockedfiles(case, skip=skip)
 

--- a/CIME/data/config/xml_schemas/entry_id.xsd
+++ b/CIME/data/config/xml_schemas/entry_id.xsd
@@ -19,6 +19,7 @@
 	<xs:element ref="schema" minOccurs="0"/>
       </xs:choice>
       <xs:attribute ref="id" use="required"/>
+      <xs:attribute ref="lock_on_restart" use="optional"/>
     </xs:complexType>
   </xs:element>
 

--- a/CIME/data/config/xml_schemas/entry_id_base.xsd
+++ b/CIME/data/config/xml_schemas/entry_id_base.xsd
@@ -8,6 +8,7 @@
   <xs:attribute name="grid"  type="xs:string"/>
   <xs:attribute name="modifier" type="xs:NCName"/>
   <xs:attribute name="match" type="xs:NCName"/>
+  <xs:attribute name="lock_on_restart" type="xs:string"/>
   <xs:attribute name="version" type="xs:decimal"/>
 
   <!-- simple elements -->

--- a/CIME/data/config/xml_schemas/env_entry_id.xsd
+++ b/CIME/data/config/xml_schemas/env_entry_id.xsd
@@ -21,6 +21,7 @@
       </xs:choice>
       <xs:attribute ref="id" use="required"/>
       <xs:attribute ref="value" />
+      <xs:attribute ref="lock_on_restart" />
     </xs:complexType>
   </xs:element>
 

--- a/CIME/locked_files.py
+++ b/CIME/locked_files.py
@@ -6,6 +6,7 @@ from CIME.XML.env_build import EnvBuild
 from CIME.XML.env_mach_pes import EnvMachPes
 from CIME.XML.env_case import EnvCase
 from CIME.XML.env_batch import EnvBatch
+from CIME.XML.env_run import EnvRun
 from CIME.XML.generic_xml import GenericXML
 
 logger = logging.getLogger(__name__)
@@ -134,6 +135,10 @@ def _get_case_env(case, caseroot, locked_file, env_name):
     elif env_name == "env_batch":
         l_env = case.get_env("batch")
         r_env = EnvBatch(caseroot, str(locked_file), read_only=True)
+    # Handle env_run XML object initialization for locked file comparisons
+    elif env_name == "env_run":
+        l_env = case.get_env("run")
+        r_env = EnvRun(caseroot, str(locked_file), read_only=True)
     else:
         raise NameError(
             "Locked XML file {!r} is not currently being handled".format(
@@ -145,6 +150,17 @@ def _get_case_env(case, caseroot, locked_file, env_name):
 
 
 def check_diff(case, filename, env_name, diff, quiet=False):
+    """Compare current XML case environment settings against locked snapshots in LockedFiles/.
+
+    Handles rebuild triggers, reset requirements, and enforces lock_on_restart constraints.
+
+    Args:
+        case (Case): The active CIME case object.
+        filename (str): Basename of the XML file being checked (e.g. 'env_run.xml').
+        env_name (str): XML environment identifier prefix (e.g. 'env_run').
+        diff (dict[str, tuple[str, str]]): Mapping of modified variable keys to (current_val, locked_val).
+        quiet (bool, optional): If True, logs warning messages instead of raising CIMEError. Defaults to False.
+    """
     logger.warning("Detected diff in locked file {!r}".format(filename))
 
     # Remove BUILD_COMPLETE, invalid entry in diff
@@ -188,6 +204,21 @@ def check_diff(case, filename, env_name, diff, quiet=False):
         clean_targets = "--clean-all"
     elif env_name in ("env_batch", "env_mach_pes"):
         reset = True
+    # Abort if any variable marked lock_on_restart is modified when CONTINUE_RUN is true
+    elif env_name == "env_run" and diff:
+        locked_restart_vars = []
+        l_env = case.get_env("run")
+        for key in diff:
+            if l_env.is_lock_on_restart(key):
+                locked_restart_vars.append(key)
+        if locked_restart_vars and case.get_value("CONTINUE_RUN"):
+            vars_str = ", ".join(f"'{v}'" for v in locked_restart_vars)
+            expect(
+                False,
+                f"Cannot change variable(s) {vars_str} on a continued run (CONTINUE_RUN=TRUE)",
+            )
+        else:
+            return
 
     for component in case.get_values("COMP_CLASSES"):
         triggers = case.get_values(f"REBUILD_TRIGGER_{component}")

--- a/CIME/tests/test_unit_locked_files.py
+++ b/CIME/tests/test_unit_locked_files.py
@@ -381,6 +381,32 @@ class TestLockedFiles(unittest.TestCase):
         # Should not raise CIMEError
         locked_files.check_diff(case, "env_run.xml", "env_run", diff)
 
+    def test_continue_run_true_with_locked_var_changed(self):
+        """Verify that enabling CONTINUE_RUN=TRUE when a lock_on_restart variable has changed raises CIMEError."""
+        case = mock.MagicMock()
+        l_env = mock.MagicMock()
+        l_env.is_lock_on_restart.side_effect = lambda k: k == "CALENDAR"
+        case.get_env.return_value = l_env
+        case.get_value.side_effect = lambda k: True if k == "CONTINUE_RUN" else ()
+
+        diff = {"CONTINUE_RUN": ("TRUE", "FALSE"), "CALENDAR": ("GREGORIAN", "NO_LEAP")}
+
+        expected_msg = "Cannot change variable\\(s\\) 'CALENDAR' on a continued run \\(CONTINUE_RUN=TRUE\\)"
+        with self.assertRaisesRegex(CIMEError, expected_msg):
+            locked_files.check_diff(case, "env_run.xml", "env_run", diff)
+
+    def test_continue_run_true_with_no_locked_var_changed(self):
+        """Verify that enabling CONTINUE_RUN=TRUE when no lock_on_restart variable has changed passes cleanly."""
+        case = mock.MagicMock()
+        l_env = mock.MagicMock()
+        l_env.is_lock_on_restart.side_effect = lambda k: False
+        case.get_env.return_value = l_env
+        case.get_value.side_effect = lambda k: True if k == "CONTINUE_RUN" else ()
+
+        diff = {"CONTINUE_RUN": ("TRUE", "FALSE"), "STOP_N": ("10", "5")}
+        # Should not raise CIMEError
+        locked_files.check_diff(case, "env_run.xml", "env_run", diff)
+
     def test_is_lock_on_restart(self):
         """Verify that EntryID.is_lock_on_restart detects lock_on_restart attributes or tags."""
         with tempfile.NamedTemporaryFile("w+", suffix=".xml") as tf:

--- a/CIME/tests/test_unit_locked_files.py
+++ b/CIME/tests/test_unit_locked_files.py
@@ -342,3 +342,61 @@ class TestLockedFiles(unittest.TestCase):
             dst_path = Path(tempdir, locked_files.LOCKED_DIR, "env_case.xml")
 
             assert dst_path.exists()
+
+    def test_check_diff_env_run_lock_on_restart(self):
+        """Verify that modifying a lock_on_restart variable when CONTINUE_RUN=TRUE raises a CIMEError."""
+        case = mock.MagicMock()
+        l_env = mock.MagicMock()
+        l_env.is_lock_on_restart.side_effect = lambda k: k == "CALENDAR"
+        case.get_env.return_value = l_env
+        case.get_value.side_effect = lambda k: True if k == "CONTINUE_RUN" else ()
+
+        diff = {"CALENDAR": ("GREGORIAN", "NO_LEAP")}
+
+        expected_msg = "Cannot change variable\\(s\\) 'CALENDAR' on a continued run \\(CONTINUE_RUN=TRUE\\)"
+        with self.assertRaisesRegex(CIMEError, expected_msg):
+            locked_files.check_diff(case, "env_run.xml", "env_run", diff)
+
+    def test_check_diff_env_run_not_continue_run(self):
+        """Verify that modifying a lock_on_restart variable when CONTINUE_RUN=FALSE does not raise an error."""
+        case = mock.MagicMock()
+        l_env = mock.MagicMock()
+        l_env.is_lock_on_restart.side_effect = lambda k: k == "CALENDAR"
+        case.get_env.return_value = l_env
+        case.get_value.side_effect = lambda k: False if k == "CONTINUE_RUN" else ()
+
+        diff = {"CALENDAR": ("GREGORIAN", "NO_LEAP")}
+        # Should not raise CIMEError
+        locked_files.check_diff(case, "env_run.xml", "env_run", diff)
+
+    def test_check_diff_env_run_unlocked_var_continue_run(self):
+        """Verify that modifying a non-lock_on_restart variable when CONTINUE_RUN=TRUE does not raise an error."""
+        case = mock.MagicMock()
+        l_env = mock.MagicMock()
+        l_env.is_lock_on_restart.side_effect = lambda k: False
+        case.get_env.return_value = l_env
+        case.get_value.side_effect = lambda k: True if k == "CONTINUE_RUN" else ()
+
+        diff = {"STOP_N": ("10", "5")}
+        # Should not raise CIMEError
+        locked_files.check_diff(case, "env_run.xml", "env_run", diff)
+
+    def test_is_lock_on_restart(self):
+        """Verify that EntryID.is_lock_on_restart detects lock_on_restart attributes or tags."""
+        with tempfile.NamedTemporaryFile("w+", suffix=".xml") as tf:
+            tf.write("""<entry_id>
+<entry id="VAR_LOCKED" lock_on_restart="true">
+  <type>char</type>
+</entry>
+<entry id="VAR_UNLOCKED">
+  <type>char</type>
+</entry>
+</entry_id>""")
+            tf.flush()
+            entry_id = EntryID(tf.name)
+            self.assertTrue(entry_id.is_lock_on_restart("VAR_LOCKED"))
+            self.assertFalse(entry_id.is_lock_on_restart("VAR_UNLOCKED"))
+            self.assertFalse(entry_id.is_lock_on_restart("NON_EXISTENT_VAR"))
+
+
+


### PR DESCRIPTION
## Description

Adds support for a `lock_on_restart="true"` attribute on XML configuration entries, preventing users from modifying restart-sensitive variables (such as `CALENDAR`) mid-simulation during continuation runs (`CONTINUE_RUN=TRUE`).

### Summary of Changes:
1. **XML Schema Support**: Updated `entry_id_base.xsd`, `entry_id.xsd`, and `env_entry_id.xsd` to recognize `lock_on_restart`.
2. **EntryID Attribute Inspection**: Added `EntryID.is_lock_on_restart(vid_or_node)` in `CIME/XML/entry_id.py`.
3. **Locked Files Validation**: Extended `_get_case_env` and `check_diff` in `CIME/locked_files.py` to compare `env_run.xml` against `LockedFiles/env_run.xml`. When `CONTINUE_RUN=TRUE`, modifying any `lock_on_restart="true"` variable triggers a clean error (`Cannot change variable(s) ... on a continued run (CONTINUE_RUN=TRUE)`).
4. **Automatic Snapshotting**: Updated `CIME/case/case_run.py` (`_pre_run_check`) to snapshot `env_run.xml` into `LockedFiles/` prior to execution when `CONTINUE_RUN=FALSE`. On continuation runs (`CONTINUE_RUN=TRUE`), the initial baseline snapshot is preserved.
5. **Unit Tests**: Added test suite coverage in `CIME/tests/test_unit_locked_files.py` (28 tests passing, including explicit transition tests for enabling `CONTINUE_RUN=TRUE` with locked vs. unlocked variable diffs).

- Related to [ESCOMP/CTSM#4122](https://github.com/ESCOMP/CTSM/issues/4122) (provides CIME `lock_on_restart` infrastructure)

### Preview of Child Branches / Stacked PRs:
- [#685](https://github.com/ESCOMP/CMEPS/pull/685) (`johnpaulalex:fix/calendar-4122-cmeps`): Moves `CALENDAR` to `env_run.xml` and marks `lock_on_restart="true"`.

### Generative AI usage:
Google Antigravity was used to write the code and tests, followed by human-guided verification.

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that exercise my feature/fix and existing tests continue to pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation