### PR TITLE
fix incorrect finalization of aborted cam_standalone runs

### DIFF
--- a/CIME/case/case_run.py
+++ b/CIME/case/case_run.py
@@ -343,6 +343,16 @@ def _post_run_check(case, lid):
             )
         elif os.stat(model_logfile).st_size == 0:
             expect(False, "Run FAILED")
+        else:
+            # The existence/size checks above pass even when the model aborts
+            # mid-run, so also require a termination message in the component
+            # log. CAM writes "END OF MODEL RUN" on successful completion.
+            with open(model_logfile, "r") as fd:
+                logfile = fd.read()
+            expect(
+                any([x in logfile for x in TERMINATION_TEXT]),
+                "Model did not complete - see {} \n ".format(model_logfile),
+            )
     else:
         count_ok = 0
         for cpl_logfile in cpl_logs:

--- a/CIME/case/case_run.py
+++ b/CIME/case/case_run.py
@@ -346,7 +346,8 @@ def _post_run_check(case, lid):
         else:
             # The existence/size checks above pass even when the model aborts
             # mid-run, so also require a termination message in the component
-            # log. CAM writes "END OF MODEL RUN" on successful completion.
+            # log. This comp_standalone logic is currently designed for CAM,
+            # which writes "END OF MODEL RUN" on successful completion.
             with open(model_logfile, "r") as fd:
                 logfile = fd.read()
             expect(


### PR DESCRIPTION
## Description
CAM standalone compsets (all stub components except CAM) are treated as a successful completion even when the model aborts (e.g., tar's all the log files). These compsets include FKESSLER and FHS94. Included a fix here that nests logic inside the  ```if comp_standalone``` block that reads the ```model_logfile``` and checks for ```TERMINATION_TEXT```.

- Addresses part of #5023 

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
