### PR TITLE
Make jenkins_generic_job glob more strict by adding mach_comp

### DIFF
--- a/CIME/jenkins_generic_job.py
+++ b/CIME/jenkins_generic_job.py
@@ -38,9 +38,7 @@ def delete_old_test_data(
     ###############################################################################
     # Remove old dirs
     for clutter_area in [scratch_root, test_root, run_area, build_area, archive_area]:
-        for old_file in glob.glob(
-            f"{clutter_area}/*{mach_comp}*{test_id_root}*"
-        ):
+        for old_file in glob.glob(f"{clutter_area}/*{mach_comp}*{test_id_root}*"):
             if avoid_test_id not in old_file:
                 logging.info(f"TEST ARCHIVER: removing {old_file}")
                 if os.path.isdir(old_file):
@@ -59,9 +57,7 @@ def scan_for_test_ids(old_test_archive, mach_comp, test_id_root):
     ###############################################################################
     results = set([])
     test_id_re = re.compile(".+[.]([^.]+)")
-    for item in glob.glob(
-        f"{old_test_archive}/old_cases/*{mach_comp}*{test_id_root}*"
-    ):
+    for item in glob.glob(f"{old_test_archive}/old_cases/*{mach_comp}*{test_id_root}*"):
         filename = os.path.basename(item)
         the_match = test_id_re.match(filename)
         if the_match:
@@ -99,18 +95,14 @@ def archive_old_test_data(
 
     # Remove the old CTest XML, same reason as above
     if os.path.isdir("Testing"):
-        logging.info(
-            f"TEST ARCHIVER: Removing {os.path.join(os.getcwd(), 'Testing')}"
-        )
+        logging.info(f"TEST ARCHIVER: Removing {os.path.join(os.getcwd(), 'Testing')}")
         shutil.rmtree("Testing")
 
     if not os.path.exists(old_test_archive):
         os.mkdir(old_test_archive)
 
     # Archive old data by looking at old test cases
-    for old_case in glob.glob(
-        f"{test_root}/*{mach_comp}*{test_id_root}[0-9]*"
-    ):
+    for old_case in glob.glob(f"{test_root}/*{mach_comp}*{test_id_root}[0-9]*"):
         if avoid_test_id not in old_case:
             logging.info(f"TEST ARCHIVER: archiving case {old_case}")
             exeroot, rundir, archdir = run_cmd_no_fail(
@@ -171,9 +163,7 @@ def archive_old_test_data(
         )
         old_test_ids = scan_for_test_ids(old_test_archive, mach_comp, test_id_root)
         for old_test_id in sorted(old_test_ids):
-            logging.info(
-                f"TEST ARCHIVER:   Removing old data for test {old_test_id}"
-            )
+            logging.info(f"TEST ARCHIVER:   Removing old data for test {old_test_id}")
             for item in ["old_cases", "old_builds", "old_runs", "old_archives"]:
                 for dir_to_rm in glob.glob(
                     f"{old_test_archive}/{item}/*{mach_comp}*{old_test_id}*"
@@ -394,7 +384,7 @@ def jenkins_generic_job(
     os.environ["CIME_MACHINE"] = machine.get_machine_name()
 
     mach_comp = f"{machine.get_machine_name()}_{compiler}"
-    globstr   = f"{test_root}/*{mach_comp}*{test_id}/TestStatus"
+    globstr = f"{test_root}/*{mach_comp}*{test_id}/TestStatus"
     if submit_to_cdash:
         logging.info(
             f"To resubmit to dashboard: wait_for_tests {globstr} --no-wait -b {cdash_build_name}"

--- a/CIME/jenkins_generic_job.py
+++ b/CIME/jenkins_generic_job.py
@@ -10,16 +10,14 @@ def cleanup_queue(test_root, test_id):
     """
     Delete all jobs left in the queue
     """
-    for teststatus_file in glob.iglob("{}/*{}*/TestStatus".format(test_root, test_id)):
+    for teststatus_file in glob.iglob(f"{test_root}/*{test_id}*/TestStatus"):
         case_dir = os.path.dirname(teststatus_file)
         with Case(case_dir, read_only=True) as case:
             jobmap = case.get_job_info()
             jobkills = []
             for jobname, jobid in jobmap.items():
                 logging.warning(
-                    "Found leftover batch job {} ({}) that need to be deleted".format(
-                        jobid, jobname
-                    )
+                    f"Found leftover batch job {jobid} ({jobname}) that need to be deleted"
                 )
                 jobkills.append(jobid)
 
@@ -41,10 +39,10 @@ def delete_old_test_data(
     # Remove old dirs
     for clutter_area in [scratch_root, test_root, run_area, build_area, archive_area]:
         for old_file in glob.glob(
-            "{}/*{}*{}*".format(clutter_area, mach_comp, test_id_root)
+            f"{clutter_area}/*{mach_comp}*{test_id_root}*"
         ):
             if avoid_test_id not in old_file:
-                logging.info("TEST ARCHIVER: removing {}".format(old_file))
+                logging.info(f"TEST ARCHIVER: removing {old_file}")
                 if os.path.isdir(old_file):
                     shutil.rmtree(old_file)
                 else:
@@ -52,9 +50,7 @@ def delete_old_test_data(
 
             else:
                 logging.info(
-                    "TEST ARCHIVER: leaving case {} due to avoiding test id {}".format(
-                        old_file, avoid_test_id
-                    )
+                    f"TEST ARCHIVER: leaving case {old_file} due to avoiding test id {avoid_test_id}"
                 )
 
 
@@ -64,7 +60,7 @@ def scan_for_test_ids(old_test_archive, mach_comp, test_id_root):
     results = set([])
     test_id_re = re.compile(".+[.]([^.]+)")
     for item in glob.glob(
-        "{}/{}/*{}*{}*".format(old_test_archive, "old_cases", mach_comp, test_id_root)
+        f"{old_test_archive}/old_cases/*{mach_comp}*{test_id_root}*"
     ):
         filename = os.path.basename(item)
         the_match = test_id_re.match(filename)
@@ -91,20 +87,20 @@ def archive_old_test_data(
     bytes_allowed = gb_allowed * 1000000000
     expect(
         bytes_allowed > 0,
-        "Machine {} does not support test archiving".format(machine.get_machine_name()),
+        f"Machine {machine.get_machine_name()} does not support test archiving",
     )
 
     # Remove old cs.status, cs.submit. I don't think there's any value to leaving these around
     # or archiving them
-    for old_cs_file in glob.glob("{}/cs.*.{}[0-9]*".format(test_root, test_id_root)):
+    for old_cs_file in glob.glob(f"{test_root}/cs.*.{test_id_root}[0-9]*"):
         if avoid_test_id not in old_cs_file:
-            logging.info("TEST ARCHIVER: Removing {}".format(old_cs_file))
+            logging.info(f"TEST ARCHIVER: Removing {old_cs_file}")
             os.remove(old_cs_file)
 
     # Remove the old CTest XML, same reason as above
     if os.path.isdir("Testing"):
         logging.info(
-            "TEST ARCHIVER: Removing {}".format(os.path.join(os.getcwd(), "Testing"))
+            f"TEST ARCHIVER: Removing {os.path.join(os.getcwd(), 'Testing')}"
         )
         shutil.rmtree("Testing")
 
@@ -113,10 +109,10 @@ def archive_old_test_data(
 
     # Archive old data by looking at old test cases
     for old_case in glob.glob(
-        "{}/*{}*{}[0-9]*".format(test_root, mach_comp, test_id_root)
+        f"{test_root}/*{mach_comp}*{test_id_root}[0-9]*"
     ):
         if avoid_test_id not in old_case:
-            logging.info("TEST ARCHIVER: archiving case {}".format(old_case))
+            logging.info(f"TEST ARCHIVER: archiving case {old_case}")
             exeroot, rundir, archdir = run_cmd_no_fail(
                 "./xmlquery EXEROOT RUNDIR DOUT_S_ROOT --value", from_dir=old_case
             ).split(",")
@@ -130,9 +126,7 @@ def archive_old_test_data(
                 if os.path.exists(the_dir):
                     start_time = time.time()
                     logging.info(
-                        "TEST ARCHIVER:   archiving {} to {}".format(
-                            the_dir, os.path.join(old_test_archive, target_area)
-                        )
+                        f"TEST ARCHIVER:   archiving {the_dir} to {os.path.join(old_test_archive, target_area)}"
                     )
                     if not os.path.exists(os.path.join(old_test_archive, target_area)):
                         os.mkdir(os.path.join(old_test_archive, target_area))
@@ -142,7 +136,7 @@ def archive_old_test_data(
                         os.path.join(
                             old_test_archive,
                             target_area,
-                            "{}.tar.gz".format(old_case_name),
+                            f"{old_case_name}.tar.gz",
                         ),
                         "w:gz",
                     ) as tfd:
@@ -159,56 +153,46 @@ def archive_old_test_data(
 
                     end_time = time.time()
                     logging.info(
-                        "TEST ARCHIVER:   archiving {} took {} seconds".format(
-                            the_dir, int(end_time - start_time)
-                        )
+                        f"TEST ARCHIVER:   archiving {the_dir} took {int(end_time - start_time)} seconds"
                     )
 
         else:
             logging.info(
-                "TEST ARCHIVER: leaving case {} due to avoiding test id {}".format(
-                    old_case, avoid_test_id
-                )
+                f"TEST ARCHIVER: leaving case {old_case} due to avoiding test id {avoid_test_id}"
             )
 
     # Check size of archive
     bytes_of_old_test_data = int(
-        run_cmd_no_fail("du -sb {}".format(old_test_archive)).split()[0]
+        run_cmd_no_fail(f"du -sb {old_test_archive}").split()[0]
     )
     if bytes_of_old_test_data > bytes_allowed:
         logging.info(
-            "TEST ARCHIVER: Too much test data, {}GB (actual) > {}GB (limit)".format(
-                bytes_of_old_test_data / 1000000000, bytes_allowed / 1000000000
-            )
+            f"TEST ARCHIVER: Too much test data, {bytes_of_old_test_data / 1000000000}GB (actual) > {bytes_allowed / 1000000000}GB (limit)"
         )
         old_test_ids = scan_for_test_ids(old_test_archive, mach_comp, test_id_root)
         for old_test_id in sorted(old_test_ids):
             logging.info(
-                "TEST ARCHIVER:   Removing old data for test {}".format(old_test_id)
+                f"TEST ARCHIVER:   Removing old data for test {old_test_id}"
             )
             for item in ["old_cases", "old_builds", "old_runs", "old_archives"]:
                 for dir_to_rm in glob.glob(
-                    "{}/{}/*{}*{}*".format(
-                        old_test_archive, item, mach_comp, old_test_id
-                    )
+                    f"{old_test_archive}/{item}/*{mach_comp}*{old_test_id}*"
                 ):
-                    logging.info("TEST ARCHIVER:     Removing {}".format(dir_to_rm))
+                    logging.info(f"TEST ARCHIVER:     Removing {dir_to_rm}")
                     if os.path.isdir(dir_to_rm):
                         shutil.rmtree(dir_to_rm)
                     else:
                         os.remove(dir_to_rm)
 
             bytes_of_old_test_data = int(
-                run_cmd_no_fail("du -sb {}".format(old_test_archive)).split()[0]
+                run_cmd_no_fail(f"du -sb {old_test_archive}").split()[0]
             )
             if bytes_of_old_test_data < bytes_allowed:
                 break
 
     else:
         logging.info(
-            "TEST ARCHIVER: Test data is within accepted bounds, {}GB (actual) < {}GB (limit)".format(
-                bytes_of_old_test_data / 1000000000, bytes_allowed / 1000000000
-            )
+            f"TEST ARCHIVER: Test data is within accepted bounds, {bytes_of_old_test_data / 1000000000}GB (actual) < {bytes_allowed / 1000000000}GB (limit)"
         )
 
 
@@ -228,7 +212,7 @@ def handle_old_test_data(
     )  # Assumes XXX/archive/$CASE
     old_test_archive = os.path.join(scratch_root, "old_test_archive")
 
-    mach_comp = "{}_{}".format(machine.get_machine_name(), compiler)
+    mach_comp = f"{machine.get_machine_name()}_{compiler}"
 
     try:
         archive_old_test_data(
@@ -241,9 +225,7 @@ def handle_old_test_data(
         )
     except Exception:
         logging.warning(
-            "TEST ARCHIVER: Archiving of old test data FAILED: {}\nDeleting data instead".format(
-                sys.exc_info()[1]
-            )
+            f"TEST ARCHIVER: Archiving of old test data FAILED: {sys.exc_info()[1]}\nDeleting data instead"
         )
         delete_old_test_data(
             mach_comp,
@@ -327,12 +309,10 @@ def jenkins_generic_job(
 
     if jenkins_id is not None:
         test_id_root = jenkins_id
-        test_id = "%s%s" % (test_id_root, CIME.utils.get_timestamp("%y%m%d_%H%M%S"))
+        test_id = f"{test_id_root}{CIME.utils.get_timestamp('%y%m%d_%H%M%S')}"
     else:
-        test_id_root = "J{}{}".format(
-            baseline_name.capitalize(), test_suite.replace("e3sm_", "").capitalize()
-        )
-        test_id = "%s%s" % (test_id_root, CIME.utils.get_timestamp())
+        test_id_root = f"J{baseline_name.capitalize()}{test_suite.replace('e3sm_', '').capitalize()}"
+        test_id = f"{test_id_root}{CIME.utils.get_timestamp()}"
     archiver_thread = threading.Thread(
         target=handle_old_test_data,
         args=(machine, compiler, test_id_root, scratch_root, test_root, test_id),
@@ -345,10 +325,10 @@ def jenkins_generic_job(
 
     create_test_args = [
         test_suite,
-        "--test-root %s" % test_root,
-        "-t %s" % test_id,
-        "--machine %s" % machine.get_machine_name(),
-        "--compiler %s" % compiler,
+        f"--test-root {test_root}",
+        f"-t {test_id}",
+        f"--machine {machine.get_machine_name()}",
+        f"--compiler {compiler}",
     ]
     if generate_baselines:
         create_test_args.append("-g -b " + real_baseline_name)
@@ -362,7 +342,7 @@ def jenkins_generic_job(
         create_test_args.append("--no-batch")
 
     if parallel_jobs is not None:
-        create_test_args.append("-j {:d}".format(parallel_jobs))
+        create_test_args.append(f"-j {parallel_jobs:d}")
 
     if walltime is not None:
         create_test_args.append("--walltime " + walltime)
@@ -395,9 +375,7 @@ def jenkins_generic_job(
         # Create_test should have either passed, detected failing tests, or timed out
         expect(
             create_test_stat in [0, CIME.utils.TESTS_FAILED_ERR_CODE, -signal.SIGTERM],
-            "Create_test script FAILED with error code '{:d}'!".format(
-                create_test_stat
-            ),
+            f"Create_test script FAILED with error code '{create_test_stat:d}'!",
         )
 
     #
@@ -415,15 +393,15 @@ def jenkins_generic_job(
 
     os.environ["CIME_MACHINE"] = machine.get_machine_name()
 
+    mach_comp = f"{machine.get_machine_name()}_{compiler}"
+    globstr   = f"{test_root}/*{mach_comp}*{test_id}/TestStatus"
     if submit_to_cdash:
         logging.info(
-            "To resubmit to dashboard: wait_for_tests {}/*{}/TestStatus --no-wait -b {}".format(
-                test_root, test_id, cdash_build_name
-            )
+            f"To resubmit to dashboard: wait_for_tests {globstr} --no-wait -b {cdash_build_name}"
         )
 
     tests_passed = CIME.wait_for_tests.wait_for_tests(
-        glob.glob("{}/*{}/TestStatus".format(test_root, test_id)),
+        glob.glob(globstr),
         no_wait=not use_batch,  # wait if using queue
         check_throughput=check_throughput,
         check_memory=check_memory,

--- a/CIME/tests/test_sys_jenkins_generic_job.py
+++ b/CIME/tests/test_sys_jenkins_generic_job.py
@@ -135,6 +135,68 @@ class TestJenkinsGenericJob(base.BaseTestCase):
         )
         self.assert_dashboard_has_build(build_name)
 
+    def test_jenkins_generic_job_compiler_isolation(self):
+        """Two runs sharing a jenkins-id but using different compilers must not
+        interfere with each other.  The cleanup/archive logic in
+        handle_old_test_data scopes its glob patterns by mach_comp
+        (``{machine}_{compiler}``), so a run with compiler B should leave the
+        test-case directories produced by a prior run with compiler A
+        completely untouched."""
+        compilers = self.MACHINE.get_value("COMPILERS").split(",")
+        compilers = [c.strip() for c in compilers if c.strip()]
+        if len(compilers) < 2:
+            self.skipTest(
+                "Need at least 2 compilers to test compiler isolation; "
+                f"only found: {compilers}"
+            )
+
+        compiler_a = compilers[0]
+        compiler_b = compilers[1]
+        jenkins_id = f"ciso_{utils.get_timestamp()}"
+        machine_name = self.MACHINE.get_machine_name()
+        mach_comp_a = f"{machine_name}_{compiler_a}"
+        mach_comp_b = f"{machine_name}_{compiler_b}"
+
+        # First run: compiler A
+        self.simple_test(
+            True,
+            f"-t cime_test_only_pass --compiler {compiler_a} --jenkins-id {jenkins_id} -b {self._baseline_name}",
+        )
+
+        # Capture the directories created by compiler A's run.
+        dirs_a = glob.glob(f"{self._jenkins_root}/*{mach_comp_a}*/")
+        self.assertGreater(
+            len(dirs_a),
+            0,
+            msg=f"Expected test directories for compiler {compiler_a} in {self._jenkins_root}",
+        )
+
+        # Second run: compiler B, same jenkins-id
+        self.simple_test(
+            True,
+            f"-t cime_test_only_pass --compiler {compiler_b} --jenkins-id {jenkins_id} -b {self._baseline_name}",
+        )
+
+        # Compiler A's directories must still be present — compiler B's
+        # cleanup/archive pass must not have touched them.
+        dirs_a_after = glob.glob(f"{self._jenkins_root}/*{mach_comp_a}*/")
+        self.assertEqual(
+            set(dirs_a),
+            set(dirs_a_after),
+            msg=(
+                f"Compiler {compiler_b} run altered directories belonging to "
+                f"compiler {compiler_a}. Before: {dirs_a}. After: {dirs_a_after}."
+            ),
+        )
+
+        # Sanity-check: compiler B also produced its own directories.
+        dirs_b = glob.glob(f"{self._jenkins_root}/*{mach_comp_b}*/")
+        self.assertGreater(
+            len(dirs_b),
+            0,
+            msg=f"Expected test directories for compiler {compiler_b} in {self._jenkins_root}",
+        )
+
     def test_jenkins_generic_job_realistic_dash(self):
         # The actual quality of the cdash results for this test can only
         # be inspected manually

--- a/CIME/wait_for_tests.py
+++ b/CIME/wait_for_tests.py
@@ -376,7 +376,10 @@ def create_cdash_upload_xml(
                         except CIMEError:
                             continue
 
-                    log_dst_dir = log_path / f"{test_name}{'' if case_dir == test_case_dir else '.case2'}_{param}_logs"
+                    log_dst_dir = (
+                        log_path
+                        / f"{test_name}{'' if case_dir == test_case_dir else '.case2'}_{param}_logs"
+                    )
                     log_dst_dir.mkdir(parents=True)
                     for log_file in glob.glob(os.path.join(log_src_dir, "*log*")):
                         if os.path.isdir(log_file):
@@ -639,9 +642,7 @@ def wait_for_test(
 
             else:
                 if wait and not SIGNAL_RECEIVED:
-                    logging.debug(
-                        f"File '{test_status_filepath}' does not yet exist"
-                    )
+                    logging.debug(f"File '{test_status_filepath}' does not yet exist")
                     time.sleep(SLEEP_INTERVAL_SEC)
                 else:
                     test_name = os.path.abspath(test_status_filepath).split("/")[-2]

--- a/CIME/wait_for_tests.py
+++ b/CIME/wait_for_tests.py
@@ -42,7 +42,7 @@ def get_test_time(test_path):
     ts = TestStatus(test_dir=test_path)
     comment = ts.get_comment(RUN_PHASE)
     if "time=" not in comment:
-        logging.warning("No run-phase time data found in {}".format(test_path))
+        logging.warning(f"No run-phase time data found in {test_path}")
         return 0
     else:
         time_data = [token for token in comment.split() if token.startswith("time=")][0]
@@ -83,7 +83,7 @@ def get_test_output(test_path):
     if os.path.exists(output_file):
         return open(output_file, "r").read()
     else:
-        logging.warning("File '{}' not found".format(output_file))
+        logging.warning(f"File '{output_file}' not found")
         return ""
 
 
@@ -100,7 +100,7 @@ def create_cdash_xml_boiler(
     site_elem = xmlet.Element("Site")
 
     site_elem.attrib["BuildName"] = cdash_build_name
-    site_elem.attrib["BuildStamp"] = "{}-{}".format(utc_time, cdash_build_group)
+    site_elem.attrib["BuildStamp"] = f"{utc_time}-{cdash_build_group}"
     site_elem.attrib["Name"] = hostname
     site_elem.attrib["OSName"] = "Linux"
     site_elem.attrib["Hostname"] = hostname
@@ -110,7 +110,7 @@ def create_cdash_xml_boiler(
 
     xmlet.SubElement(phase_elem, "StartDateTime").text = time.ctime(current_time)
     xmlet.SubElement(
-        phase_elem, "Start{}Time".format("Test" if phase == "Testing" else phase)
+        phase_elem, f"Start{'Test' if phase == 'Testing' else phase}Time"
     ).text = str(int(current_time))
 
     return site_elem, phase_elem
@@ -147,9 +147,7 @@ def create_cdash_config_xml(
         nml_phase_result = get_test_phase(test_norm_path, NAMELIST_PHASE)
         if nml_phase_result == TEST_FAIL_STATUS:
             nml_diff = get_nml_diff(test_norm_path)
-            cdash_warning = "CMake Warning:\n\n{} NML DIFF:\n{}\n".format(
-                test_name, nml_diff
-            )
+            cdash_warning = f"CMake Warning:\n\n{test_name} NML DIFF:\n{nml_diff}\n"
             config_results.append(cdash_warning)
 
     xmlet.SubElement(config_elem, "Log").text = "\n".join(config_results)
@@ -372,17 +370,13 @@ def create_cdash_upload_xml(
                         # will not be able to support xmlquery
                         try:
                             log_src_dir = run_cmd_no_fail(
-                                "./xmlquery {} --value".format(param),
+                                f"./xmlquery {param} --value",
                                 from_dir=case_dir,
                             )
                         except CIMEError:
                             continue
 
-                    log_dst_dir = log_path / "{}{}_{}_logs".format(
-                        test_name,
-                        "" if case_dir == test_case_dir else ".case2",
-                        param,
-                    )
+                    log_dst_dir = log_path / f"{test_name}{'' if case_dir == test_case_dir else '.case2'}_{param}_logs"
                     log_dst_dir.mkdir(parents=True)
                     for log_file in glob.glob(os.path.join(log_src_dir, "*log*")):
                         if os.path.isdir(log_file):
@@ -400,34 +394,27 @@ def create_cdash_upload_xml(
 
     if need_to_upload:
 
-        tarball = "{}.tar.gz".format(log_dirname)
+        tarball = f"{log_dirname}.tar.gz"
 
         run_cmd_no_fail(
-            "tar -cf - {} | gzip -c".format(log_dirname),
+            f"tar -cf - {log_dirname} | gzip -c",
             arg_stdout=tarball,
             from_dir=str(tmp_path),
         )
-        base64 = run_cmd_no_fail("base64 {}".format(tarball), from_dir=str(tmp_path))
+        base64 = run_cmd_no_fail(f"base64 {tarball}", from_dir=str(tmp_path))
 
-        xml_text = r"""<?xml version="1.0" encoding="UTF-8"?>
+        xml_text = f"""<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="Dart/Source/Server/XSL/Build.xsl <file:///Dart/Source/Server/XSL/Build.xsl> "?>
-<Site BuildName="{}" BuildStamp="{}-{}" Name="{}" Generator="ctest3.0.0">
+<Site BuildName="{cdash_build_name}" BuildStamp="{utc_time}-{cdash_build_group}" Name="{hostname}" Generator="ctest3.0.0">
 <Upload>
-<File filename="{}">
+<File filename="{str((tmp_path / tarball).absolute())}">
 <Content encoding="base64">
-{}
+{base64}
 </Content>
 </File>
 </Upload>
 </Site>
-""".format(
-            cdash_build_name,
-            utc_time,
-            cdash_build_group,
-            hostname,
-            str((tmp_path / tarball).absolute()),
-            base64,
-        )
+"""
 
         with (data_rel_path / "Upload.xml").open(mode="w") as fd:
             fd.write(xml_text)
@@ -457,7 +444,7 @@ def create_cdash_xml(
     if hostname is None:
         hostname = socket.gethostname().split(".")[0]
         logging.warning(
-            "Could not convert hostname '{}' into an E3SM machine name".format(hostname)
+            f"Could not convert hostname '{hostname}' into an E3SM machine name"
         )
 
     # We assume all cases were created from the same code repo
@@ -531,43 +518,35 @@ def create_cdash_xml(
                 )
 
                 for drop_method in ["https", "http"]:
-                    dart_config = """
-SourceDirectory: {0}
-BuildDirectory: {0}
+                    dart_config = f"""
+SourceDirectory: {str(tmp_path.absolute())}
+BuildDirectory: {str(tmp_path.absolute())}
 
 # Site is something like machine.domain, i.e. pragmatic.crd
-Site: {1}
+Site: {hostname}
 
 # Build name is osname-revision-compiler, i.e. Linux-2.4.2-2smp-c++
-BuildName: {2}
+BuildName: {cdash_build_name}
 
 # Submission information
 IsCDash: TRUE
 CDashVersion:
 QueryCDashVersion:
 DropSite: my.cdash.org
-DropLocation: /submit.php?project={3}
+DropLocation: /submit.php?project={cdash_project}
 DropSiteUser:
 DropSitePassword:
 DropSiteMode:
-DropMethod: {6}
+DropMethod: {drop_method}
 TriggerSite:
-ScpCommand: {4}
+ScpCommand: {shutil.which('scp')}
 
 # Dashboard start time
-NightlyStartTime: {5} UTC
+NightlyStartTime: {cdash_timestamp} UTC
 
 UseLaunchers:
 CurlOptions: CURLOPT_SSL_VERIFYPEER_OFF;CURLOPT_SSL_VERIFYHOST_OFF
-""".format(
-                        str(tmp_path.absolute()),
-                        hostname,
-                        cdash_build_name,
-                        cdash_project,
-                        shutil.which("scp"),
-                        cdash_timestamp,
-                        drop_method,
-                    )
+"""
                     with dart_path.open(mode="w") as dart_fd:
                         dart_fd.write(dart_config)
 
@@ -578,12 +557,10 @@ CurlOptions: CURLOPT_SSL_VERIFYPEER_OFF;CURLOPT_SSL_VERIFYHOST_OFF
                     )
                     if stat != 0:
                         logging.warning(
-                            "ctest upload drop method {} FAILED:\n{}".format(
-                                drop_method, out
-                            )
+                            f"ctest upload drop method {drop_method} FAILED:\n{out}"
                         )
                     else:
-                        logging.info("Upload SUCCESS:\n{}".format(out))
+                        logging.info(f"Upload SUCCESS:\n{out}")
                         if ENV_VAR_KEEP_CDASH in os.environ:
                             logging.info(
                                 f"Test mode enabled, copying {str(tmp_path)} to {os.getcwd()}"
@@ -618,7 +595,7 @@ def wait_for_test(
     else:
         test_status_filepath = test_path
 
-    logging.debug("Watching file: '{}'".format(test_status_filepath))
+    logging.debug(f"Watching file: '{test_status_filepath}'")
     test_log_path = os.path.join(
         os.path.dirname(test_status_filepath), ".internal_test_status.log"
     )
@@ -649,7 +626,7 @@ def wait_for_test(
 
                 if prior_ts is not None and prior_ts != ts:
                     log_fd.write(ts.phase_statuses_dump())
-                    log_fd.write("OVERALL: {}\n\n".format(test_status))
+                    log_fd.write(f"OVERALL: {test_status}\n\n")
 
                 prior_ts = ts
 
@@ -663,7 +640,7 @@ def wait_for_test(
             else:
                 if wait and not SIGNAL_RECEIVED:
                     logging.debug(
-                        "File '{}' does not yet exist".format(test_status_filepath)
+                        f"File '{test_status_filepath}' does not yet exist"
                     )
                     time.sleep(SLEEP_INTERVAL_SEC)
                 else:
@@ -672,7 +649,7 @@ def wait_for_test(
                         (
                             test_name,
                             test_path,
-                            "File '{}' doesn't exist".format(test_status_filepath),
+                            f"File '{test_status_filepath}' doesn't exist",
                             CREATE_NEWCASE_PHASE,
                         )
                     )
@@ -724,29 +701,23 @@ def wait_for_tests_impl(
             prior_path, prior_status, _ = test_results[test_name]
             if test_status == prior_status:
                 logging.warning(
-                    "Test name '{}' was found in both '{}' and '{}'".format(
-                        test_name, test_path, prior_path
-                    )
+                    f"Test name '{test_name}' was found in both '{test_path}' and '{prior_path}'"
                 )
             else:
                 raise CIMEError(
-                    "Test name '{}' was found in both '{}' and '{}' with different results".format(
-                        test_name, test_path, prior_path
-                    )
+                    f"Test name '{test_name}' was found in both '{test_path}' and '{prior_path}' with different results"
                 )
 
         expect(
             test_name is not None,
-            "Failed to get test name for test_path: {}".format(test_path),
+            f"Failed to get test name for test_path: {test_path}",
         )
         test_results[test_name] = (test_path, test_status, test_phase)
         completed_test_paths.append(test_path)
 
     expect(
         set(test_paths) == set(completed_test_paths),
-        "Missing results for test paths: {}".format(
-            set(test_paths) - set(completed_test_paths)
-        ),
+        f"Missing results for test paths: {set(test_paths) - set(completed_test_paths)}",
     )
     return test_results
 
@@ -799,7 +770,7 @@ def wait_for_tests(
             NAMELIST_FAIL_STATUS,
         ]:
             # Report failed phases
-            logging.info("{} {} (phase {})".format(test_status, test_name, phase))
+            logging.info(f"{test_status} {test_name} (phase {phase})")
             all_pass = False
         else:
             # Be cautious about telling the user that the test passed since we might
@@ -807,33 +778,27 @@ def wait_for_tests(
             if test_status == TEST_PEND_STATUS:
                 if expect_test_complete:
                     logging.info(
-                        "{} {} (phase {} unexpectedly left in PEND)".format(
-                            TEST_PEND_STATUS, test_name, phase
-                        )
+                        f"{TEST_PEND_STATUS} {test_name} (phase {phase} unexpectedly left in PEND)"
                     )
                     all_pass = False
                 else:
                     logging.info(
-                        "{} {} (phase {} has not yet completed)".format(
-                            TEST_PEND_STATUS, test_name, phase
-                        )
+                        f"{TEST_PEND_STATUS} {test_name} (phase {phase} has not yet completed)"
                     )
 
             elif test_status == NAMELIST_FAIL_STATUS:
                 logging.info(
-                    "{} {} (but otherwise OK) {}".format(
-                        NAMELIST_FAIL_STATUS, test_name, phase
-                    )
+                    f"{NAMELIST_FAIL_STATUS} {test_name} (but otherwise OK) {phase}"
                 )
                 all_pass = False
             else:
                 expect(
                     test_status == TEST_PASS_STATUS,
-                    "Expected pass if we made it here, instead: {}".format(test_status),
+                    f"Expected pass if we made it here, instead: {test_status}",
                 )
-                logging.info("{} {} {}".format(test_status, test_name, phase))
+                logging.info(f"{test_status} {test_name} {phase}")
 
-        logging.info("    Case dir: {}".format(case_dir))
+        logging.info(f"    Case dir: {case_dir}")
 
         if update_success or (cdash_build_name and not env_loaded):
             try:
@@ -857,9 +822,7 @@ def wait_for_tests(
 
             except CIMEError as e:
                 logging.warning(
-                    "Failed to update success / load_env for Case {}: {}".format(
-                        case_dir, e
-                    )
+                    f"Failed to update success / load_env for Case {case_dir}: {e}"
                 )
 
     if cdash_build_name:


### PR DESCRIPTION
Also, transition jenkins and wait_for_tests to modern py string formatting.

We hit a very unlikely edge case where two PM jobs kicked off near the same time and ended up picking the same timestamp, which messed a lot of things up. Making the glob have the mach_comp in addition to the timestamp will prevent this from happening again.

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
