### PR TITLE
Add utility for locking directories

### DIFF
--- a/CIME/core/exceptions.py
+++ b/CIME/core/exceptions.py
@@ -38,6 +38,10 @@ class LockingError(CIMEError):
     """Case locking or unlocking failure."""
 
 
+class CimeTimeoutError(CIMEError):
+    """Timeout errors."""
+
+
 class ExternalCommandError(CIMEError):
     """An external command (subprocess) failed.
 

--- a/CIME/tests/test_unit_utils.py
+++ b/CIME/tests/test_unit_utils.py
@@ -6,7 +6,6 @@ import shutil
 import sys
 import tempfile
 
-import pytest
 import unittest
 from unittest import mock
 from CIME.status import run_and_log_case_status
@@ -440,41 +439,47 @@ class TestUtils(unittest.TestCase):
             self.assertMatchAllLines(tempdir, test_lines)
 
 
-class TestDistributedDirLock:
+class TestDistributedDirLock(unittest.TestCase):
     """Tests for the distributed_dir_lock context manager."""
 
-    def test_distributed_dir_lock_acquires_and_releases(self, tmp_path):
+    def setUp(self):
+        self._workdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self._workdir, ignore_errors=True)
+
+    def test_distributed_dir_lock_acquires_and_releases(self):
         # Context
-        lock_dir = tmp_path / _CIME_LOCK_DIR_NAME
+        lock_dir = os.path.join(self._workdir, _CIME_LOCK_DIR_NAME)
 
         # Act / Assert
-        with distributed_dir_lock(str(tmp_path)):
-            assert lock_dir.exists()
+        with distributed_dir_lock(self._workdir):
+            self.assertTrue(os.path.isdir(lock_dir))
 
-        assert not lock_dir.exists()
+        self.assertFalse(os.path.exists(lock_dir))
 
-    def test_distributed_dir_lock_releases_on_exception(self, tmp_path):
+    def test_distributed_dir_lock_releases_on_exception(self):
         # Context
-        lock_dir = tmp_path / _CIME_LOCK_DIR_NAME
+        lock_dir = os.path.join(self._workdir, _CIME_LOCK_DIR_NAME)
 
         # Act / Assert
-        with pytest.raises(RuntimeError):
-            with distributed_dir_lock(str(tmp_path)):
+        with self.assertRaises(RuntimeError):
+            with distributed_dir_lock(self._workdir):
                 raise RuntimeError("body error")
 
-        assert not lock_dir.exists()
+        self.assertFalse(os.path.exists(lock_dir))
 
-    def test_distributed_dir_lock_timeout(self, tmp_path):
+    def test_distributed_dir_lock_timeout(self):
         # Context — pre-create the lock dir to simulate a held lock
-        lock_dir = tmp_path / _CIME_LOCK_DIR_NAME
-        lock_dir.mkdir()
+        lock_dir = os.path.join(self._workdir, _CIME_LOCK_DIR_NAME)
+        os.mkdir(lock_dir)
 
         # Act / Assert
-        with pytest.raises(TimeoutError):
-            with distributed_dir_lock(str(tmp_path), poll_interval=0.01, timeout=0.05):
+        with self.assertRaises(TimeoutError):
+            with distributed_dir_lock(self._workdir, poll_interval=0.01, timeout=0.05):
                 pass
 
-    def test_distributed_dir_lock_retries_until_acquired(self, tmp_path):
+    def test_distributed_dir_lock_retries_until_acquired(self):
         # Context
         original_mkdir = os.mkdir
         attempt = {"count": 0}
@@ -488,19 +493,19 @@ class TestDistributedDirLock:
         # Mocks
         with mock.patch("os.mkdir", side_effect=flaky_mkdir):
             # Act
-            with distributed_dir_lock(str(tmp_path), poll_interval=0.001):
+            with distributed_dir_lock(self._workdir, poll_interval=0.001):
                 pass
 
         # Assert
-        assert attempt["count"] == 3
+        self.assertEqual(attempt["count"], 3)
 
-    def test_distributed_dir_lock_handles_external_cleanup(self, tmp_path):
+    def test_distributed_dir_lock_handles_external_cleanup(self):
         # Context
-        lock_dir = tmp_path / _CIME_LOCK_DIR_NAME
+        lock_dir = os.path.join(self._workdir, _CIME_LOCK_DIR_NAME)
 
         # Act / Assert — no error when lock dir is removed externally before release
-        with distributed_dir_lock(str(tmp_path)):
-            lock_dir.rmdir()
+        with distributed_dir_lock(self._workdir):
+            os.rmdir(lock_dir)
 
 
 if __name__ == "__main__":

--- a/CIME/tests/test_unit_utils.py
+++ b/CIME/tests/test_unit_utils.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import tempfile
 
+import pytest
 import unittest
 from unittest import mock
 from CIME.status import run_and_log_case_status
@@ -16,6 +17,8 @@ from CIME.utils import (
     file_contains_python_function,
     copy_globs,
     import_and_run_sub_or_cmd,
+    distributed_dir_lock,
+    _CIME_LOCK_DIR_NAME,
 )
 
 
@@ -435,6 +438,69 @@ class TestUtils(unittest.TestCase):
                 run_and_log_case_status(self.error_func, "default", caseroot=tempdir)
 
             self.assertMatchAllLines(tempdir, test_lines)
+
+
+class TestDistributedDirLock:
+    """Tests for the distributed_dir_lock context manager."""
+
+    def test_distributed_dir_lock_acquires_and_releases(self, tmp_path):
+        # Context
+        lock_dir = tmp_path / _CIME_LOCK_DIR_NAME
+
+        # Act / Assert
+        with distributed_dir_lock(str(tmp_path)):
+            assert lock_dir.exists()
+
+        assert not lock_dir.exists()
+
+    def test_distributed_dir_lock_releases_on_exception(self, tmp_path):
+        # Context
+        lock_dir = tmp_path / _CIME_LOCK_DIR_NAME
+
+        # Act / Assert
+        with pytest.raises(RuntimeError):
+            with distributed_dir_lock(str(tmp_path)):
+                raise RuntimeError("body error")
+
+        assert not lock_dir.exists()
+
+    def test_distributed_dir_lock_timeout(self, tmp_path):
+        # Context — pre-create the lock dir to simulate a held lock
+        lock_dir = tmp_path / _CIME_LOCK_DIR_NAME
+        lock_dir.mkdir()
+
+        # Act / Assert
+        with pytest.raises(TimeoutError):
+            with distributed_dir_lock(str(tmp_path), poll_interval=0.01, timeout=0.05):
+                pass
+
+    def test_distributed_dir_lock_retries_until_acquired(self, tmp_path):
+        # Context
+        original_mkdir = os.mkdir
+        attempt = {"count": 0}
+
+        def flaky_mkdir(path):
+            attempt["count"] += 1
+            if attempt["count"] < 3:
+                raise FileExistsError()
+            original_mkdir(path)
+
+        # Mocks
+        with mock.patch("os.mkdir", side_effect=flaky_mkdir):
+            # Act
+            with distributed_dir_lock(str(tmp_path), poll_interval=0.001):
+                pass
+
+        # Assert
+        assert attempt["count"] == 3
+
+    def test_distributed_dir_lock_handles_external_cleanup(self, tmp_path):
+        # Context
+        lock_dir = tmp_path / _CIME_LOCK_DIR_NAME
+
+        # Act / Assert — no error when lock dir is removed externally before release
+        with distributed_dir_lock(str(tmp_path)):
+            lock_dir.rmdir()
 
 
 if __name__ == "__main__":

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -2718,7 +2718,10 @@ def is_comp_standalone(case):
         return True, model
     return False, None
 
+
 _CIME_LOCK_DIR_NAME = "cime_utils_distributed_dir_lock"
+
+
 @contextmanager
 def distributed_dir_lock(dir_path, poll_interval=0.2, timeout=None):
     """
@@ -2742,7 +2745,9 @@ def distributed_dir_lock(dir_path, poll_interval=0.2, timeout=None):
         except FileExistsError:
             # Check if we have timed out while waiting
             if timeout is not None and (time.time() - start_time) > timeout:
-                raise TimeoutError(f"Failed to acquire lock at {lock_dir_path} within {timeout} seconds.")
+                raise TimeoutError(  # pylint: disable=raise-missing-from
+                    f"Failed to acquire lock at {lock_dir_path} within {timeout} seconds."
+                )
 
             # Lock is busy; wait and try again
             time.sleep(poll_interval)

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -155,7 +155,7 @@ class EnvironmentContext(object):
 #
 # Canonical definition lives in CIME.core.exceptions; re-exported here
 # for backward compatibility.
-from CIME.core.exceptions import CIMEError  # noqa: F401
+from CIME.core.exceptions import CIMEError, CimeTimeoutError  # noqa: F401
 
 
 def expect(condition, error_msg, exc_type=CIMEError, error_prefix="ERROR:"):
@@ -2745,8 +2745,8 @@ def distributed_dir_lock(dir_path, poll_interval=0.2, timeout=None):
         except FileExistsError:
             # Check if we have timed out while waiting
             if timeout is not None and (time.time() - start_time) > timeout:
-                raise TimeoutError(  # pylint: disable=raise-missing-from
-                    f"Failed to acquire lock at {lock_dir_path} within {timeout} seconds."
+                raise CimeTimeoutError(  # pylint: disable=raise-missing-from
+                    f"Failed to acquire lock at {lock_dir_path} within {timeout} seconds. It's possible that a process crashed while holding the lock and this directory will need to be manually removed."
                 )
 
             # Lock is busy; wait and try again

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -2219,24 +2219,6 @@ def transform_vars(text, case=None, subgroup=None, overrides=None, default=None)
     return text
 
 
-def wait_for_unlocked(filepath):
-    locked = True
-    file_object = None
-    while locked:
-        try:
-            buffer_size = 8
-            # Opening file in append mode and read the first 8 characters.
-            file_object = open(filepath, "a", buffer_size)
-            if file_object:
-                locked = False
-        except IOError:
-            locked = True
-            time.sleep(1)
-        finally:
-            if file_object:
-                file_object.close()
-
-
 def gunzip_existing_file(filepath):
     with gzip.open(filepath, "rb") as fd:
         return fd.read()
@@ -2735,3 +2717,44 @@ def is_comp_standalone(case):
     if stubcnt >= numclasses - 2:
         return True, model
     return False, None
+
+_CIME_LOCK_DIR_NAME = "cime_utils_distributed_dir_lock"
+@contextmanager
+def distributed_dir_lock(dir_path, poll_interval=0.2, timeout=None):
+    """
+    An atomic directory-based distributed lock for shared network filesystems.
+
+    :param dir_path: Path to the directory you want to lock. Only this directory will be locked
+    :param poll_interval: Time (seconds) to wait between retry attempts.
+    :param timeout: Maximum time (seconds) to wait for lock acquisition before raising TimeoutError.
+    """
+    start_time = time.time()
+    acquired = False
+
+    lock_dir_path = os.path.join(dir_path, _CIME_LOCK_DIR_NAME)
+
+    while True:
+        try:
+            # os.mkdir is atomic over network filesystems (NFS, SMB, EFS)
+            os.mkdir(lock_dir_path)
+            acquired = True
+            break
+        except FileExistsError:
+            # Check if we have timed out while waiting
+            if timeout is not None and (time.time() - start_time) > timeout:
+                raise TimeoutError(f"Failed to acquire lock at {lock_dir_path} within {timeout} seconds.")
+
+            # Lock is busy; wait and try again
+            time.sleep(poll_interval)
+
+    try:
+        # Pass control back to the 'with' block
+        yield
+    finally:
+        # This block ALWAYS runs, even if the code inside the 'with' statement crashes
+        if acquired:
+            try:
+                os.rmdir(lock_dir_path)
+            except FileNotFoundError:
+                # Handle edge case where lock was manually cleaned up externally
+                pass


### PR DESCRIPTION
## Description

This allows clients to achieve a MUTEX for a specific directory. This
can be useful for buildnmls that want to make changes to shared
directories, allowing them to avoid race conditions.

## Checklist
- [ ] My code follows the style guidelines of this project (black formatting)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
