### PR TITLE
Remove auto-triage feature

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -26,7 +26,7 @@ from CIME.hist_utils import (
     generate_baseline,
 )
 from CIME.config import Config
-from CIME.provenance import save_test_time, get_test_success
+from CIME.provenance import save_test_time
 from CIME.locked_files import LOCKED_DIR, lock_file, is_locked
 from CIME.baselines.performance import (
     get_latest_cpl_logs,
@@ -616,61 +616,6 @@ class SystemTestsCommon(object):
                         time_taken,
                         get_current_commit(repo=srcroot),
                     )
-
-                # If overall things did not pass, offer the user some insight into what might have broken things
-                overall_status = self._test_status.get_overall_test_status(
-                    ignore_namelists=True
-                )[0]
-                if overall_status != TEST_PASS_STATUS:
-                    srcroot = self._case.get_value("SRCROOT")
-                    worked_before, last_pass, last_fail_transition = get_test_success(
-                        baseline_root, srcroot, self._casebaseid
-                    )
-
-                    if worked_before:
-                        if last_pass is not None:
-                            # commits between last_pass and now broke things
-                            stat, out, err = run_cmd(
-                                "git rev-list --first-parent {}..{}".format(
-                                    last_pass, "HEAD"
-                                ),
-                                from_dir=srcroot,
-                            )
-                            if stat == 0:
-                                append_testlog(
-                                    "NEW FAIL: Potentially broken merges:\n{}".format(
-                                        out
-                                    ),
-                                    self._orig_caseroot,
-                                )
-                            else:
-                                logger.warning(
-                                    "Unable to list potentially broken merges: {}\n{}".format(
-                                        out, err
-                                    )
-                                )
-                    else:
-                        if last_pass is not None and last_fail_transition is not None:
-                            # commits between last_pass and last_fail_transition broke things
-                            stat, out, err = run_cmd(
-                                "git rev-list --first-parent {}..{}".format(
-                                    last_pass, last_fail_transition
-                                ),
-                                from_dir=srcroot,
-                            )
-                            if stat == 0:
-                                append_testlog(
-                                    "OLD FAIL: Potentially broken merges:\n{}".format(
-                                        out
-                                    ),
-                                    self._orig_caseroot,
-                                )
-                            else:
-                                logger.warning(
-                                    "Unable to list potentially broken merges: {}\n{}".format(
-                                        out, err
-                                    )
-                                )
 
             if config.baseline_store_teststatus and self._case.get_value(
                 "GENERATE_BASELINE"


### PR DESCRIPTION
## Description

This feature was never robust due to git interactions and potential shallow clones etc. I don't think anyone was getting value from this and it was just cluttering output and confusing people.

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
