### PR TITLE
Test scheduler improvements

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -796,7 +796,6 @@ class EnvBatch(EnvBase):
               waiting to resubmit at the end of the first sequence
         workflow is a logical indicating whether only "job" is submitted or the workflow sequence starting with "job" is submitted
         """
-
         external_workflow = case.get_value("EXTERNAL_WORKFLOW")
         if not self._env_workflow:
             self._env_workflow = case.get_env("workflow")
@@ -816,38 +815,43 @@ class EnvBatch(EnvBase):
 
         startindex = 0
         jobs = []
-        if job is not None:
-            expect(job in alljobs, "Do not know about batch job {}".format(job))
-            startindex = alljobs.index(job)
-        for index, job in enumerate(alljobs):
-            logger.debug(
-                "Index {:d} job {} startindex {:d}".format(index, job, startindex)
-            )
-            if index < startindex:
-                continue
-            try:
-                prereq = self._env_workflow.get_value(
-                    "prereq", subgroup=job, resolved=False
+        if workflow:
+            if job is not None:
+                expect(job in alljobs, "Do not know about batch job {}".format(job))
+                startindex = alljobs.index(job)
+            for index, job in enumerate(alljobs):
+                logger.debug(
+                    "Index {:d} job {} startindex {:d}".format(index, job, startindex)
                 )
-                if external_workflow or prereq is None or dry_run:
-                    prereq = True
-                else:
-                    prereq = case.get_resolved_value(prereq)
-                    prereq = eval(prereq)
-            except Exception:
-                expect(
-                    False,
-                    "Unable to evaluate prereq expression '{}' for job '{}'".format(
-                        self.get_value("prereq", subgroup=job), job
-                    ),
-                )
-            if prereq:
-                jobs.append(
-                    (job, self._env_workflow.get_value("dependency", subgroup=job))
-                )
+                if index < startindex:
+                    continue
+                try:
+                    prereq = self._env_workflow.get_value(
+                        "prereq", subgroup=job, resolved=False
+                    )
+                    if external_workflow or prereq is None or dry_run:
+                        prereq = True
+                    else:
+                        prereq = case.get_resolved_value(prereq)
+                        prereq = eval(prereq)
+                except Exception:
+                    expect(
+                        False,
+                        "Unable to evaluate prereq expression '{}' for job '{}'".format(
+                            self.get_value("prereq", subgroup=job), job
+                        ),
+                    )
+                if prereq:
+                    jobs.append(
+                        (job, self._env_workflow.get_value("dependency", subgroup=job))
+                    )
 
-            if self._batchtype == "cobalt":
-                break
+                if self._batchtype == "cobalt":
+                    break
+
+        else:
+            expect(job, "If not following workflow, please specific which job to submit")
+            jobs = [(job, None)]
 
         depid = OrderedDict()
         jobcmds = []

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -850,7 +850,9 @@ class EnvBatch(EnvBase):
                     break
 
         else:
-            expect(job, "If not following workflow, please specific which job to submit")
+            expect(
+                job, "If not following workflow, please specific which job to submit"
+            )
             jobs = [(job, None)]
 
         depid = OrderedDict()

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -851,8 +851,9 @@ class EnvBatch(EnvBase):
 
         else:
             expect(
-                job, "If not following workflow, please specific which job to submit"
+                job, "If not following workflow, please specify which job to submit"
             )
+            expect(job in alljobs, "Do not know about batch job {}".format(job))
             jobs = [(job, None)]
 
         depid = OrderedDict()

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -850,9 +850,7 @@ class EnvBatch(EnvBase):
                     break
 
         else:
-            expect(
-                job, "If not following workflow, please specify which job to submit"
-            )
+            expect(job, "If not following workflow, please specify which job to submit")
             expect(job in alljobs, "Do not know about batch job {}".format(job))
             jobs = [(job, None)]
 

--- a/CIME/get_tests.py
+++ b/CIME/get_tests.py
@@ -239,7 +239,12 @@ def get_test_suites():
 
 ###############################################################################
 def get_test_suite(
-        suite, machine=None, compiler=None, skip_inherit=False, skip_tests=None, machobj=None
+    suite,
+    machine=None,
+    compiler=None,
+    skip_inherit=False,
+    skip_tests=None,
+    machobj=None,
 ):
     ###############################################################################
     """
@@ -285,7 +290,9 @@ def get_test_suite(
 
     if not skip_inherit:
         for inherits in inherits_from:
-            inherited_tests = get_test_suite(inherits, machine, compiler, machobj=machobj)
+            inherited_tests = get_test_suite(
+                inherits, machine, compiler, machobj=machobj
+            )
 
             for inherited_test in inherited_tests:
                 if inherited_test not in tests:
@@ -299,12 +306,18 @@ def suite_has_test(suite, test_full_name, skip_inherit=False, machobj=None):
     ###############################################################################
     _, _, _, _, machine, compiler, _ = CIME.utils.parse_test_name(test_full_name)
     expect(machine is not None, "{} is not a full test name".format(test_full_name))
-    if (machobj is not None):
-        expect(machine == machobj.get_machine_name(),
-               f"machobj '{machobj.get_machine_name()}' does not match parsed machine '{machine}'")
+    if machobj is not None:
+        expect(
+            machine == machobj.get_machine_name(),
+            f"machobj '{machobj.get_machine_name()}' does not match parsed machine '{machine}'",
+        )
 
     tests = get_test_suite(
-        suite, machine=machine, compiler=compiler, skip_inherit=skip_inherit, machobj=machobj
+        suite,
+        machine=machine,
+        compiler=compiler,
+        skip_inherit=skip_inherit,
+        machobj=machobj,
     )
     return test_full_name in tests
 

--- a/CIME/get_tests.py
+++ b/CIME/get_tests.py
@@ -239,14 +239,14 @@ def get_test_suites():
 
 ###############################################################################
 def get_test_suite(
-    suite, machine=None, compiler=None, skip_inherit=False, skip_tests=None
+        suite, machine=None, compiler=None, skip_inherit=False, skip_tests=None, machobj=None
 ):
     ###############################################################################
     """
     Return a list of FULL test names for a suite.
     """
     expect(suite in get_test_suites(), "Unknown test suite: '{}'".format(suite))
-    machobj = Machines(machine=machine)
+    machobj = Machines(machine=machine) if machobj is None else machobj
     machine = machobj.get_machine_name()
 
     if compiler is None:
@@ -285,7 +285,7 @@ def get_test_suite(
 
     if not skip_inherit:
         for inherits in inherits_from:
-            inherited_tests = get_test_suite(inherits, machine, compiler)
+            inherited_tests = get_test_suite(inherits, machine, compiler, machobj=machobj)
 
             for inherited_test in inherited_tests:
                 if inherited_test not in tests:
@@ -295,19 +295,22 @@ def get_test_suite(
 
 
 ###############################################################################
-def suite_has_test(suite, test_full_name, skip_inherit=False):
+def suite_has_test(suite, test_full_name, skip_inherit=False, machobj=None):
     ###############################################################################
     _, _, _, _, machine, compiler, _ = CIME.utils.parse_test_name(test_full_name)
     expect(machine is not None, "{} is not a full test name".format(test_full_name))
+    if (machobj is not None):
+        expect(machine == machobj.get_machine_name(),
+               f"machobj '{machobj.get_machine_name()}' does not match parsed machine '{machine}'")
 
     tests = get_test_suite(
-        suite, machine=machine, compiler=compiler, skip_inherit=skip_inherit
+        suite, machine=machine, compiler=compiler, skip_inherit=skip_inherit, machobj=machobj
     )
     return test_full_name in tests
 
 
 ###############################################################################
-def get_build_groups(tests):
+def get_build_groups(tests, machobj=None):
     ###############################################################################
     """
     Given a list of tests, return a list of lists, with each list representing
@@ -349,7 +352,7 @@ def get_build_groups(tests):
         # Find which suites have this test
         my_share_suites = set()
         for suite in share_suites:
-            if suite_has_test(suite, test, skip_inherit=True):
+            if suite_has_test(suite, test, skip_inherit=True, machobj=machobj):
                 my_share_suites.add(suite)
 
         # Try to match this test with an existing build group. If there is

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -771,14 +771,6 @@ def parse_command_line(args, description):
         dot_count = name.count(".")
         expect(dot_count > 1 and dot_count <= 4, "Invalid test Name, '{}'".format(name))
 
-    # for e3sm, sort by walltime
-    if model_config.sort_tests:
-        if args.walltime is None:
-            # Longest tests should run first
-            test_names.sort(key=get_tests.key_test_time, reverse=True)
-        else:
-            test_names.sort()
-
     return (
         test_names,
         test_extra_data,

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -324,7 +324,7 @@ class TestScheduler(object):
         if parallel_jobs is None:
             mach_parallel_jobs = self._machobj.get_value("NTEST_PARALLEL_JOBS")
             if mach_parallel_jobs is None:
-                mach_parallel_jobs = self._machobj.get_value("MAX_MPITASKS_PER_NODE")
+                mach_parallel_jobs = self._machobj.get_value("MAX_TASKS_PER_NODE")
             self._parallel_jobs = min(len(test_names), mach_parallel_jobs)
         else:
             self._parallel_jobs = parallel_jobs
@@ -481,7 +481,7 @@ class TestScheduler(object):
             self._build_groups = [tuple(self._tests.keys())]
         elif self._config.share_exes:
             # Any test that's in a shared-enabled suite with other tests should share exes
-            self._build_groups = get_build_groups(self._tests)
+            self._build_groups = get_build_groups(self._tests, machobj=self._machobj)
         else:
             self._build_groups = [(item,) for item in self._tests]
 

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -2764,9 +2764,11 @@ def distributed_dir_lock(dir_path, poll_interval=0.2, timeout=None):
                 # Handle edge case where lock was manually cleaned up externally
                 pass
 
+
 class SectionTimer:
     def __init__(self, name):
         self.name = name
+        self.start = None
 
     def __enter__(self):
         self.start = time.perf_counter()

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -2763,3 +2763,15 @@ def distributed_dir_lock(dir_path, poll_interval=0.2, timeout=None):
             except FileNotFoundError:
                 # Handle edge case where lock was manually cleaned up externally
                 pass
+
+class SectionTimer:
+    def __init__(self, name):
+        self.name = name
+
+    def __enter__(self):
+        self.start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        elapsed = time.perf_counter() - self.start
+        print(f"[Timer] {self.name} took {elapsed:.4f} seconds")


### PR DESCRIPTION
## Description

Fix very poor performance on create_test/test_scheduler startup. The root cause was repeated initialization of Machine object which requires a lot of file I/O and XML stuff. Since test_scheduler already makes a Machine object, just reuse that one if possible.

Also, there is no need to sort test cases twice.

Also, when asking env_batch to submit a specific job without doing a full workflow sequence, it should always just do that job instead of doing a full dependency analysis.

Also, adds a simple context manager for timing sections of code.

Also, the default task-level parallelism in test_scheduler should be based off MAX_TASK_PER_NODE instead of MAX_MPITASKS_PER_NODE because the latter is very throttled for GPU.

## Checklist
- [ ] My code follows the style guidelines of this project (black formatting)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
