### PR TITLE
bless_test_result: Change case matching to regex search

### DIFF
--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -1319,11 +1319,12 @@ def start_buffering_output():
 def match_any(item, re_counts):
     """
     Return true if item matches any regex in re_counts' keys. Increments
-    count if a match was found.
+    count if a match was found. Note, this does a regex search, not a strict
+    match.
     """
     for regex_str in re_counts:
         regex = re.compile(regex_str)
-        if regex.match(item):
+        if regex.search(item):
             re_counts[regex_str] += 1
             return True
 


### PR DESCRIPTION
This makes it quite a bit more user-friendly since the frequent use case of just providing a substring is now just `substring` instead of `.*substring.*`.

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
