### PR TITLE
More cime updates

### DIFF
--- a/CIME/Tools/case.build
+++ b/CIME/Tools/case.build
@@ -94,10 +94,10 @@ def parse_command_line(args, description):
         )
 
     parser.add_argument(
-        "--no-batch-build",
+        "--batch-build",
         action="store_true",
-        help="Skip batch submission even if BATCHED_BUILD is TRUE for this machine. "
-        "Use this when you are already on a compute node or want to build interactively.",
+        help="Enable batched builds if the machine supports them. "
+        "Use this when you are on a login node or want to use batch system for builds.",
     )
 
     parser.add_argument(
@@ -217,7 +217,7 @@ def parse_command_line(args, description):
         args.gmake,
         args.dry_run,
         args.skip_submit,
-        args.no_batch_build,
+        args.batch_build,
     )
 
 
@@ -239,7 +239,7 @@ def _main_func(description):
         gmake,
         dry_run,
         skip_submit,
-        no_batch_build,
+        batch_build,
     ) = parse_command_line(sys.argv, description)
 
     success = True
@@ -299,7 +299,7 @@ def _main_func(description):
                 dry_run=dry_run,
                 separate_builds=separate_builds,
                 skip_submit=skip_submit,
-                batched_build_active=no_batch_build,
+                batched_build_active=not batch_build,
             )
 
         else:
@@ -313,7 +313,7 @@ def _main_func(description):
                 separate_builds=separate_builds,
                 ninja=ninja,
                 dry_run=dry_run,
-                batched_build_active=no_batch_build,
+                batched_build_active=not batch_build,
             )
 
     sys.exit(0 if success else 1)

--- a/CIME/Tools/jenkins_generic_job
+++ b/CIME/Tools/jenkins_generic_job
@@ -84,6 +84,12 @@ OR
     )
 
     parser.add_argument(
+        "--batch-build",
+        action="store_true",
+        help="Enable batched builds if the machine supports them",
+    )
+
+    parser.add_argument(
         "-c",
         "--cdash-build-name",
         help="Build name to use for CDash submission. Default will be <TEST_SUITE>_<BRANCH>_<COMPILER>",
@@ -265,6 +271,7 @@ OR
         args.generate_baselines,
         args.submit_to_cdash,
         args.no_batch,
+        args.batch_build,
         args.baseline_name,
         args.cdash_build_name,
         args.cdash_project,
@@ -299,6 +306,7 @@ def _main_func(description):
         generate_baselines,
         submit_to_cdash,
         no_batch,
+        batch_build,
         baseline_name,
         cdash_build_name,
         cdash_project,
@@ -331,6 +339,7 @@ def _main_func(description):
             generate_baselines,
             submit_to_cdash,
             no_batch,
+            batch_build,
             baseline_name,
             cdash_build_name,
             cdash_project,

--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -341,11 +341,10 @@ def bless_test_results(
         # Must pass tests to continue
         has_no_tests = bless_tests in [[], None]
         match_test_name = match_any(test_name, bless_tests_counts)
-        excluded = exclude.match(test_name) if exclude else False
+        excluded = exclude.search(test_name) if exclude else False
 
         if (not has_no_tests and not match_test_name) or excluded:
             logger.debug("Skipping {!r}".format(test_name))
-
             continue
 
         overall_result, phase = ts.get_overall_test_status(

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -1146,7 +1146,7 @@ def _submit_build_as_batch(
         )
 
     # Build the argument string that the batch script will receive via ARGS_FOR_SCRIPT.
-    args = ["--no-batch-build"]
+    args = []
     if sharedlib_only:
         args.append("--sharedlib-only")
     if model_only:

--- a/CIME/data/config/xml_schemas/config_machines_template.xml
+++ b/CIME/data/config/xml_schemas/config_machines_template.xml
@@ -72,7 +72,7 @@
     <!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
     <GMAKE_J>8</GMAKE_J>
 
-    <!-- BATCHED_BUILD: optional, if TRUE case.build will submit the build
+    <!-- BATCHED_BUILD: optional, if TRUE case.build will allow submission of the build
       as a batch job instead of building on the current (login) node.
       Requires a batch system to be configured (BATCH_SYSTEM != none).
       Default is FALSE. -->

--- a/CIME/jenkins_generic_job.py
+++ b/CIME/jenkins_generic_job.py
@@ -234,6 +234,7 @@ def jenkins_generic_job(
     generate_baselines,
     submit_to_cdash,
     no_batch,
+    batch_build,
     baseline_name,
     arg_cdash_build_name,
     cdash_project,
@@ -330,6 +331,9 @@ def jenkins_generic_job(
 
     if no_batch:
         create_test_args.append("--no-batch")
+
+    if batch_build:
+        create_test_args.append("--batch-build")
 
     if parallel_jobs is not None:
         create_test_args.append(f"-j {parallel_jobs:d}")

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -103,10 +103,10 @@ def parse_command_line(args, description):
     )
 
     parser.add_argument(
-        "--no-batch-build",
+        "--batch-build",
         action="store_true",
-        help="Disable batched builds (BATCHED_BUILD) even if the machine enables"
-        "\nthem by default. Builds will run interactively on the login node.",
+        help="Enable batched builds (BATCHED_BUILD) if the machine supports them."
+        "\nBuilds will be submitted to the batch system. Disabled by default.",
     )
 
     parser.add_argument(
@@ -780,7 +780,7 @@ def parse_command_line(args, description):
         args.no_build,
         args.no_setup,
         args.no_batch,
-        args.no_batch_build,
+        args.batch_build,
         args.test_root,
         args.baseline_root,
         args.clean,
@@ -946,7 +946,7 @@ def create_test(
     no_build,
     no_setup,
     no_batch,
-    no_batch_build,
+    batch_build,
     test_root,
     baseline_root,
     clean,
@@ -997,7 +997,7 @@ def create_test(
         no_build=no_build,
         no_setup=no_setup,
         no_batch=no_batch,
-        no_batch_build=no_batch_build,
+        batch_build=batch_build,
         test_root=test_root,
         test_id=test_id,
         baseline_root=baseline_root,
@@ -1101,7 +1101,7 @@ def _main_func(description=None):
         no_build,
         no_setup,
         no_batch,
-        no_batch_build,
+        batch_build,
         test_root,
         baseline_root,
         clean,
@@ -1159,7 +1159,7 @@ def _main_func(description=None):
             no_build,
             no_setup,
             no_batch,
-            no_batch_build,
+            batch_build,
             test_root,
             baseline_root,
             clean,

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -259,6 +259,8 @@ class TestScheduler(object):
             self._machobj.set_value("MPILIB", self._mpilib)
 
         self._batched_build = batch_build and self._machobj.get_value("BATCHED_BUILD")
+        if batch_build and not self._machobj.get_value("BATCHED_BUILD"):
+            logger.warning("You requested batched builds but that is not supported on the current machine (see BATCHED_BUILD)")
 
         # Compute cost on current node of doing the model build
         if self._batched_build:

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -1074,8 +1074,6 @@ class TestScheduler(object):
             return True, ""
 
         cmd = "./case.build --sharedlib-only"
-        if not self._batched_build:
-            cmd += " --no-batch-build"
         if self._ninja:
             cmd += " --ninja"
         elif self._gmake:
@@ -1134,8 +1132,8 @@ class TestScheduler(object):
             )
 
         cmd += " --model-only"
-        if not self._batched_build:
-            cmd += " --no-batch-build"
+        if self._batched_build:
+            cmd += " --batch-build"
         return self._shell_cmd_for_phase(
             test, cmd, MODEL_BUILD_PHASE, from_dir=test_dir
         )

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -260,7 +260,9 @@ class TestScheduler(object):
 
         self._batched_build = batch_build and self._machobj.get_value("BATCHED_BUILD")
         if batch_build and not self._machobj.get_value("BATCHED_BUILD"):
-            logger.warning("You requested batched builds but that is not supported on the current machine (see BATCHED_BUILD)")
+            logger.warning(
+                "You requested batched builds but that is not supported on the current machine (see BATCHED_BUILD)"
+            )
 
         # Compute cost on current node of doing the model build
         if self._batched_build:

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -214,7 +214,7 @@ class TestScheduler(object):
         workflow=None,
         chksum=False,
         force_rebuild=False,
-        no_batch_build=False,
+        batch_build=False,
         ninja=False,
         gmake=False,
         driver=None,
@@ -258,9 +258,7 @@ class TestScheduler(object):
         if self._mpilib is not None:
             self._machobj.set_value("MPILIB", self._mpilib)
 
-        self._batched_build = self._machobj.get_value("BATCHED_BUILD")
-        if no_batch_build:
-            self._batched_build = False
+        self._batched_build = batch_build and self._machobj.get_value("BATCHED_BUILD")
 
         # Compute cost on current node of doing the model build
         if self._batched_build:

--- a/CIME/tests/test_unit_test_scheduler.py
+++ b/CIME/tests/test_unit_test_scheduler.py
@@ -9,8 +9,8 @@ False on the model config, the sharedlib and model build phases are fused:
   ``./case.build --model-only``, submitting one batch job for both phases.
 
 When either condition is not met the original two-phase behaviour is kept.
-The ``no_batch_build`` constructor flag forces ``_batched_build = False``
-regardless of the machine setting.
+The ``batch_build`` constructor flag enables batched builds only if the
+machine also supports them (BATCHED_BUILD=True).
 
 The _xml_phase sets GMAKE_J to MAX_TASKS_PER_NODE when batched builds are
 enabled so the entire compute node is used for the build job.
@@ -313,29 +313,29 @@ class TestModelBuildPhaseFusion:
 
 
 # ---------------------------------------------------------------------------
-# no_batch_build constructor flag
+# batch_build constructor flag
 # ---------------------------------------------------------------------------
 
 
-class TestNoBatchBuildFlag:
-    """Tests for the no_batch_build=True constructor behaviour."""
+class TestBatchBuildFlag:
+    """Tests for the batch_build constructor behaviour."""
 
-    def test_no_batch_build_disables_batched_build(self):
-        """no_batch_build=True must set _batched_build to False, causing
+    def test_batch_build_false_disables_batched_build(self):
+        """batch_build=False (default) must set _batched_build to False, causing
         --no-batch-build to be appended to case.build calls."""
         ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=True)
-        # Simulate the __init__ logic: no_batch_build overrides _batched_build
-        ts._batched_build = False  # as __init__ would do when no_batch_build=True
+        # Simulate the __init__ logic: batch_build=False means no batching
+        ts._batched_build = False  # as __init__ would do when batch_build=False
 
         ts._sharedlib_build_phase(_TEST_NAME)
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
         assert cmd == "./case.build --sharedlib-only --no-batch-build"
 
-    def test_no_batch_build_init_param_sets_attribute(self):
-        """TestScheduler.__init__ sets _batched_build=False when no_batch_build=True."""
+    def test_batch_build_init_param_enables_batched_build(self):
+        """TestScheduler.__init__ enables batched builds when batch_build=True and machine supports it."""
         # We test the init logic in isolation by checking the attribute assignment
-        # path (lines 250-251 of test_scheduler.py) with a minimal mock.
+        # path with a minimal mock.
         with mock.patch.object(
             test_scheduler.TestScheduler,
             "__init__",
@@ -344,12 +344,12 @@ class TestNoBatchBuildFlag:
             ts = test_scheduler.TestScheduler.__new__(test_scheduler.TestScheduler)
 
         # Replicate exactly what __init__ does for this flag:
-        ts._batched_build = True  # pretend machine says True
-        no_batch_build = True
-        if no_batch_build:
-            ts._batched_build = False
+        ts._batched_build = False  # default (machine supports it but not enabled)
+        batch_build = True
+        machine_supports_it = True
+        ts._batched_build = batch_build and machine_supports_it
 
-        assert ts._batched_build is False
+        assert ts._batched_build is True
 
 
 # ---------------------------------------------------------------------------

--- a/CIME/tests/test_unit_test_scheduler.py
+++ b/CIME/tests/test_unit_test_scheduler.py
@@ -217,7 +217,6 @@ class TestSharedlibBuildPhaseFusion:
         ts._sharedlib_build_phase(_TEST_NAME)
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
-        assert "--no-batch-build" not in cmd
         assert cmd == "./case.build --sharedlib-only"
 
     def test_non_first_test_unaffected(self):
@@ -255,12 +254,12 @@ class TestModelBuildPhaseFusion:
         assert cmd == "./case.build"
 
     def test_model_only_when_serialized(self):
-        """When serialize_sharedlib_builds is True, use --model-only (batched=True, no --no-batch-build)."""
+        """When serialize_sharedlib_builds is True, use --model-only (batched=True)."""
         ts = _make_scheduler(serialize_sharedlib_builds=True, batched_build=True)
         ts._model_build_phase(_TEST_NAME)
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
-        assert cmd == "./case.build --model-only"
+        assert cmd == "./case.build --model-only --batch-build"
 
     def test_no_special_flags_when_not_batched(self):
         """When _batched_build is False, run case.build without batch flags.
@@ -270,7 +269,7 @@ class TestModelBuildPhaseFusion:
         ts._model_build_phase(_TEST_NAME)
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
-        assert cmd == "./case.build"
+        assert cmd == "./case.build --model-only"
 
     def test_no_special_flags_when_serialized_and_not_batched(self):
         """When serialize=True and batched=False, run case.build without batch flags."""
@@ -278,7 +277,6 @@ class TestModelBuildPhaseFusion:
         ts._model_build_phase(_TEST_NAME)
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
-        assert "--no-batch-build" not in cmd
         assert cmd == "./case.build --model-only"
 
     def test_full_build_uses_model_build_phase_label(self):
@@ -335,7 +333,6 @@ class TestBatchBuildFlag:
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
         assert cmd == "./case.build --sharedlib-only"
-        assert "--no-batch-build" not in cmd
 
     def test_batch_build_init_param_enables_batched_build(self):
         """TestScheduler.__init__ enables batched builds when batch_build=True and machine supports it."""

--- a/CIME/tests/test_unit_test_scheduler.py
+++ b/CIME/tests/test_unit_test_scheduler.py
@@ -197,26 +197,28 @@ class TestSharedlibBuildPhaseFusion:
             from_dir=_TEST_DIR,
         )
 
-    def test_no_batch_build_flag_appended_when_not_batched(self):
-        """When _batched_build is False, --no-batch-build is appended to prevent
-        case.build from independently submitting a batch job."""
+    def test_no_special_flags_when_not_batched(self):
+        """When _batched_build is False, run case.build without batch flags.
+        With opt-in batched builds, case.build won't submit to batch unless
+        explicitly enabled via --batch-build."""
         ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=False)
         ts._sharedlib_build_phase(_TEST_NAME)
 
         ts._shell_cmd_for_phase.assert_called_once_with(
             _TEST_NAME,
-            "./case.build --sharedlib-only --no-batch-build",
+            "./case.build --sharedlib-only",
             SHAREDLIB_BUILD_PHASE,
             from_dir=_TEST_DIR,
         )
 
-    def test_no_batch_build_flag_appended_when_serialized_and_not_batched(self):
-        """--no-batch-build is appended when both serialize=True and batched=False."""
+    def test_no_special_flags_when_serialized_and_not_batched(self):
+        """When serialize=True and batched=False, run case.build without batch flags."""
         ts = _make_scheduler(serialize_sharedlib_builds=True, batched_build=False)
         ts._sharedlib_build_phase(_TEST_NAME)
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
-        assert "--no-batch-build" in cmd
+        assert "--no-batch-build" not in cmd
+        assert cmd == "./case.build --sharedlib-only"
 
     def test_non_first_test_unaffected(self):
         """Non-build-group-leader path is unchanged by the new fusion logic."""
@@ -260,22 +262,24 @@ class TestModelBuildPhaseFusion:
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
         assert cmd == "./case.build --model-only"
 
-    def test_no_batch_build_flag_appended_when_not_batched(self):
-        """When _batched_build is False, --no-batch-build is appended to prevent
-        case.build from independently submitting a batch job."""
+    def test_no_special_flags_when_not_batched(self):
+        """When _batched_build is False, run case.build without batch flags.
+        With opt-in batched builds, case.build won't submit to batch unless
+        explicitly enabled via --batch-build."""
         ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=False)
         ts._model_build_phase(_TEST_NAME)
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
-        assert cmd == "./case.build --model-only --no-batch-build"
+        assert cmd == "./case.build"
 
-    def test_no_batch_build_flag_appended_when_serialized_and_not_batched(self):
-        """--no-batch-build is appended when both serialize=True and batched=False."""
+    def test_no_special_flags_when_serialized_and_not_batched(self):
+        """When serialize=True and batched=False, run case.build without batch flags."""
         ts = _make_scheduler(serialize_sharedlib_builds=True, batched_build=False)
         ts._model_build_phase(_TEST_NAME)
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
-        assert "--no-batch-build" in cmd
+        assert "--no-batch-build" not in cmd
+        assert cmd == "./case.build --model-only"
 
     def test_full_build_uses_model_build_phase_label(self):
         """The fused call should still be labelled MODEL_BUILD_PHASE."""
@@ -322,15 +326,16 @@ class TestBatchBuildFlag:
 
     def test_batch_build_false_disables_batched_build(self):
         """batch_build=False (default) must set _batched_build to False, causing
-        --no-batch-build to be appended to case.build calls."""
-        ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=True)
-        # Simulate the __init__ logic: batch_build=False means no batching
-        ts._batched_build = False  # as __init__ would do when batch_build=False
+        case.build to be called without batch flags (opt-in semantics)."""
+        ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=False)
+        # With opt-in model, batch_build=False means no batching
+        ts._batched_build = False
 
         ts._sharedlib_build_phase(_TEST_NAME)
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
-        assert cmd == "./case.build --sharedlib-only --no-batch-build"
+        assert cmd == "./case.build --sharedlib-only"
+        assert "--no-batch-build" not in cmd
 
     def test_batch_build_init_param_enables_batched_build(self):
         """TestScheduler.__init__ enables batched builds when batch_build=True and machine supports it."""

--- a/doc/source/ccs/building-a-case.rst
+++ b/doc/source/ccs/building-a-case.rst
@@ -31,7 +31,7 @@ Note: If CMAKE_BACKEND is something other than gmake, it will be up to the host 
 +------------------+-----------------------------------------------------------+
 | GMAKE_J          | The number of threads GNU Make should use while building. |
 +------------------+-----------------------------------------------------------+
-| BATCHED_BUILD    | Whether to batch submit build phases                      |
+| BATCHED_BUILD    | Whether to allow batch submission of build phases         |
 +------------------+-----------------------------------------------------------+
 | CMAKE_BACKEND    | The CMake backend to use                                  |
 +------------------+-----------------------------------------------------------+

--- a/doc/source/ccs/model-configuration/variables/machine.rst
+++ b/doc/source/ccs/model-configuration/variables/machine.rst
@@ -146,7 +146,7 @@ CCSM_CPRNC                  Location of the cprnc tool.
 PERL5LIB                    Perl library path.
 GMAKE                       GNU-compatible make tool.
 GMAKE_J                     Number of threads for gmake.
-BATCHED_BUILD               Optional, builds will be done through batch submissions
+BATCHED_BUILD               Optional, builds can be done through batch submissions
 CMAKE_BACKEND               Optional, tells CMake which backend to use
 TESTS                       List of tests to run on the machine.
 NTEST_PARALLEL_JOBS         Number of parallel jobs for testing.


### PR DESCRIPTION
## Description
* Fix bless_test_results --exclude option. These were being treated as regex matches, not regex searched.
* Batched builds become an opt-in instead of an opt-out feature and BATCHED_BUILD for a machine indicates that this feature is available but it still won't be the default. I wish we could make it the default, but during business hours, it's just too hard to get even a single node on some of our HPCs. The current intent will be for nightlies to use this feature so that, when plowing through a bunch of cases, build parallelism can be exposed.


## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that exercise my feature/fix and existing tests continue to pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding additions and changes to the documentation
